### PR TITLE
Add adjustable fee percentage and recipient

### DIFF
--- a/test/Lottery.test.ts
+++ b/test/Lottery.test.ts
@@ -30,4 +30,24 @@ describe("Bittery", function () {
       ]
     );
   });
+
+  it("owner can update fee percent", async function () {
+    const { lottery, owner } = await loadFixture(deployFixture);
+    await lottery.connect(owner).setFeePercent(10);
+    expect(await lottery.feePercent()).to.equal(10);
+  });
+
+  it("non-owner cannot update fee percent", async function () {
+    const { lottery, user } = await loadFixture(deployFixture);
+    await expect(lottery.connect(user).setFeePercent(10)).to.be.revertedWith(
+      "Not owner"
+    );
+  });
+
+  it("owner can update fee recipient", async function () {
+    const { lottery, owner } = await loadFixture(deployFixture);
+    const newRecipient = owner.address;
+    await lottery.connect(owner).setFeeRecipient(newRecipient);
+    expect(await lottery.feeRecipient()).to.equal(newRecipient);
+  });
 });


### PR DESCRIPTION
## Summary
- convert fee percentage and recipient constants to configurable state variables
- allow owner to modify `feePercent` and `feeRecipient`
- extend tests to cover new functions

## Testing
- `npm test`
- `npx hardhat compile`


------
https://chatgpt.com/codex/tasks/task_e_686f65ea4534832f8f54c1eea869b780