### PR TITLE
Add weekly lottery draw scheduler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@openzeppelin/contracts": "^5.3.0",
         "ethers": "^6.15.0",
         "next": "15.3.5",
+        "node-cron": "^3.0.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -7930,6 +7931,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/node-emoji": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
@@ -10594,7 +10607,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "test": "hardhat test",
     "compile": "hardhat compile",
-    "deploy": "hardhat run scripts/deploy.ts --network sepolia"
+    "deploy": "hardhat run scripts/deploy.ts --network sepolia",
+    "schedule": "ts-node scripts/scheduleDraw.ts"
   },
   "dependencies": {
     "@chainlink/contracts": "^1.4.0",
@@ -17,7 +18,8 @@
     "ethers": "^6.15.0",
     "next": "15.3.5",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "node-cron": "^3.0.3"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^6.0.0",

--- a/scripts/scheduleDraw.ts
+++ b/scripts/scheduleDraw.ts
@@ -1,0 +1,40 @@
+import { ethers } from "ethers";
+import cron from "node-cron";
+import * as dotenv from "dotenv";
+import lotteryAbi from "../contracts/Bittery.json";
+
+dotenv.config();
+
+const RPC_URL = process.env.RPC_URL || process.env.SEPOLIA_RPC_URL || "";
+const PRIVATE_KEY = process.env.PRIVATE_KEY || "";
+const CONTRACT_ADDRESS = "0xbfa9A081EDe54008287740EaD6CDE9bc7020f999";
+
+if (!RPC_URL || !PRIVATE_KEY) {
+  console.error("RPC_URL and PRIVATE_KEY must be set in the environment");
+  process.exit(1);
+}
+
+const provider = new ethers.JsonRpcProvider(RPC_URL);
+const wallet = new ethers.Wallet(PRIVATE_KEY, provider);
+const lottery = new ethers.Contract(CONTRACT_ADDRESS, lotteryAbi.abi, wallet);
+
+async function draw() {
+  try {
+    const players: string[] = await lottery.getPlayers();
+    if (players.length >= 2) {
+      const tx = await lottery.requestRandomWinner();
+      await tx.wait();
+      console.log("Winner request sent", tx.hash);
+    } else {
+      console.log(`Skipping draw, only ${players.length} player(s)`);
+    }
+  } catch (err) {
+    console.error("Failed to execute draw:", err);
+  }
+}
+
+// Run every Sunday at 20:00
+cron.schedule("0 20 * * 0", () => {
+  console.log("Running scheduled lottery draw...");
+  draw();
+});


### PR DESCRIPTION
## Summary
- add `node-cron` dependency and new npm script `schedule`
- create `scheduleDraw.ts` to automatically call `requestRandomWinner`
  every Sunday at 20:00 if 2 or more players have joined

## Testing
- `npm test` *(fails: ZeroAddress error)*

------
https://chatgpt.com/codex/tasks/task_e_686f7bd997d4832f901e09dd32406760