### PR TITLE
Translate front-end carousel to English

### DIFF
--- a/app/components/InfoCarousel.tsx
+++ b/app/components/InfoCarousel.tsx
@@ -9,20 +9,20 @@ interface Slide {
 
 const slides: Slide[] = [
   {
-    title: 'Como funciona',
-    text: 'Cada bilhete custa 0.01 ETH. Quando o sorteio é iniciado, um número aleatório da Chainlink VRF define o vencedor e todo o prêmio é enviado para ele.',
+    title: 'How It Works',
+    text: 'Each ticket costs 0.01 ETH. When the drawing starts, a random number from Chainlink VRF picks the winner and the entire prize is sent to them.',
   },
   {
-    title: 'Regras',
-    text: 'Envie exatamente 0.01 ETH ao comprar. Somente o dono do contrato pode iniciar o sorteio e existe uma taxa de 5% destinada ao endereço configurado.',
+    title: 'Rules',
+    text: 'Send exactly 0.01 ETH when buying. Only the contract owner can start the drawing and a 5% fee is sent to the configured address.',
   },
   {
-    title: 'Técnicas',
-    text: 'O contrato em Solidity utiliza o Chainlink VRF v2 para aleatoriedade. A interface foi criada com Next.js e ethers.js.',
+    title: 'Technical Details',
+    text: 'The Solidity contract uses Chainlink VRF v2 for randomness. The interface was built with Next.js and ethers.js.',
   },
   {
-    title: 'Código',
-    text: 'O projeto completo está disponível no GitHub.',
+    title: 'Code',
+    text: 'The full project is available on GitHub.',
     link: 'https://github.com/yourusername/bittery',
   },
 ];
@@ -38,11 +38,11 @@ export default function InfoCarousel() {
   return (
     <div className="w-full max-w-xl mx-auto p-6 bg-white dark:bg-neutral-900 rounded-lg shadow space-y-4">
       <div className="flex items-center justify-between">
-        <button onClick={prev} className="px-2 py-1" aria-label="Anterior">
+        <button onClick={prev} className="px-2 py-1" aria-label="Previous">
           ‹
         </button>
         <h2 className="text-2xl font-bold">{slide.title}</h2>
-        <button onClick={next} className="px-2 py-1" aria-label="Próximo">
+        <button onClick={next} className="px-2 py-1" aria-label="Next">
           ›
         </button>
       </div>


### PR DESCRIPTION
## Summary
- translate InfoCarousel slide content and navigation labels

## Testing
- `npm test` *(fails: ZeroAddress during tests)*

------
https://chatgpt.com/codex/tasks/task_e_686fa50800ec832f9980c3827884c95a