### PR TITLE
Add earnings table before launch

### DIFF
--- a/app/components/EarningsTable.tsx
+++ b/app/components/EarningsTable.tsx
@@ -1,0 +1,81 @@
+"use client";
+import { useMemo } from "react";
+
+interface RowData {
+  players: number;
+  referrals: number;
+  referralEarningsETH: number;
+  referralEarningsBRL: number;
+  chance: number;
+  prizePoolETH: number;
+  prizePoolBRL: number;
+  totalPotentialBRL: number;
+}
+
+const ETH_TO_BRL = 15400;
+const REF_PERCENT_ETH = 0.00025; // 2.5% of 0.01 ETH
+
+function generateData(start = 2, end = 50): RowData[] {
+  const data: RowData[] = [];
+  for (let players = start; players <= end; players++) {
+    const referrals = players - 1;
+    const referralEarningsETH = referrals * REF_PERCENT_ETH;
+    const referralEarningsBRL = referralEarningsETH * ETH_TO_BRL;
+    const chance = 1 / players;
+    const prizePoolETH = 0.0095 * players;
+    const prizePoolBRL = prizePoolETH * ETH_TO_BRL;
+    const totalPotentialBRL = referralEarningsBRL + prizePoolBRL * chance;
+    data.push({
+      players,
+      referrals,
+      referralEarningsETH,
+      referralEarningsBRL,
+      chance,
+      prizePoolETH,
+      prizePoolBRL,
+      totalPotentialBRL,
+    });
+  }
+  return data;
+}
+
+export default function EarningsTable() {
+  const rows = useMemo(() => generateData(), []);
+  return (
+    <div className="overflow-x-auto w-full max-w-2xl mx-auto mt-8">
+      <h2 className="text-2xl font-bold title mb-2">Lottery Earnings Table</h2>
+      <table className="min-w-full text-sm border-collapse border">
+        <thead>
+          <tr>
+            <th className="border px-2">Players</th>
+            <th className="border px-2">Referrals</th>
+            <th className="border px-2">Referral Earnings (ETH)</th>
+            <th className="border px-2">Referral Earnings (R$)</th>
+            <th className="border px-2">Chance to Win</th>
+            <th className="border px-2">Prize Pool (ETH)</th>
+            <th className="border px-2">Prize Pool (R$)</th>
+            <th className="border px-2">Total Potential Gain (R$)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.players}>
+              <td className="border px-2 text-center">{row.players}</td>
+              <td className="border px-2 text-center">{row.referrals}</td>
+              <td className="border px-2 text-right">
+                {row.referralEarningsETH.toFixed(6)}
+              </td>
+              <td className="border px-2 text-right">
+                {row.referralEarningsBRL.toFixed(2)}
+              </td>
+              <td className="border px-2 text-right">{row.chance.toFixed(4)}</td>
+              <td className="border px-2 text-right">{row.prizePoolETH.toFixed(6)}</td>
+              <td className="border px-2 text-right">{row.prizePoolBRL.toFixed(2)}</td>
+              <td className="border px-2 text-right">{row.totalPotentialBRL.toFixed(2)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { ethers } from "ethers";
 import lotteryAbi from "../contracts/Bittery.json";
 import InfoCarousel from "./components/InfoCarousel";
 import ReferralLink from "./components/ReferralLink";
+import EarningsTable from "./components/EarningsTable";
 
 const CONTRACT_ADDRESS = process.env.NEXT_PUBLIC_CONTRACT_ADDRESS || "";
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
@@ -159,6 +160,7 @@ export default function Home() {
       </div>
       <p className="text-lg">Next draw in: {timeLeft}</p>
       <InfoCarousel />
+      {!launched && <EarningsTable />}
       <div className="flex flex-col sm:flex-row gap-4">
         <button
           className="rounded bg-black text-white px-6 py-2 hover:bg-gray-800 transition-colors"


### PR DESCRIPTION
## Summary
- show lottery earnings table before launch on home page
- implement `EarningsTable` component to show referral and prize info

## Testing
- `npm test` *(fails: VM Exception with custom error `ZeroAddress()`)*

------
https://chatgpt.com/codex/tasks/task_e_686fea4ac638832f87fc89c4ee565689