### PR TITLE
Fix admin panel call with ethers v6

### DIFF
--- a/app/components/AdminPanel.tsx
+++ b/app/components/AdminPanel.tsx
@@ -73,7 +73,7 @@ export default function AdminPanel({ provider, signer }: Props) {
     if (!window.confirm("Confirm updating fee percent?")) return;
     const tx = await contract
       .connect(signer)
-      .setFeePercent(Number(feePercent));
+      .getFunction("setFeePercent")(Number(feePercent));
     await tx.wait();
     refreshValues();
   }
@@ -83,7 +83,7 @@ export default function AdminPanel({ provider, signer }: Props) {
     if (!window.confirm("Confirm updating referral percent?")) return;
     const tx = await contract
       .connect(signer)
-      .setReferralPercent(Number(referralPercent));
+      .getFunction("setReferralPercent")(Number(referralPercent));
     await tx.wait();
     refreshValues();
   }
@@ -93,7 +93,7 @@ export default function AdminPanel({ provider, signer }: Props) {
     if (!window.confirm("Confirm updating fee recipient?")) return;
     const tx = await contract
       .connect(signer)
-      .setFeeRecipient(feeRecipient);
+      .getFunction("setFeeRecipient")(feeRecipient);
     await tx.wait();
     refreshValues();
   }


### PR DESCRIPTION
## Summary
- use `contract.getFunction` to call admin methods

## Testing
- `npm test` *(fails: ZeroAddress custom error)*

------
https://chatgpt.com/codex/tasks/task_e_687007f4de8c832f99f4327b316381db