### PR TITLE
Improve SEO metadata

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,22 +1,23 @@
-"use client";
-import { useState } from "react";
-import { ethers } from "ethers";
-import ConnectWalletButton from "../components/ConnectWalletButton";
-import AdminPanel from "../components/AdminPanel";
+import type { Metadata } from "next";
+import AdminClient from "../components/AdminClient";
+
+export const metadata: Metadata = {
+  title: "Admin",
+  description: "Administrative panel for Bittery contract management",
+  openGraph: {
+    title: "Bittery Admin",
+    description: "Administrative panel for Bittery contract management",
+    images: ["/Bittery-Logo.png"],
+    url: "https://bittery.org/admin",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Bittery Admin",
+    description: "Administrative panel for Bittery contract management",
+    images: ["/Bittery-Logo.png"],
+  },
+};
 
 export default function AdminPage() {
-  const [provider, setProvider] = useState<ethers.BrowserProvider>();
-  const [signer, setSigner] = useState<ethers.JsonRpcSigner>();
-
-  return (
-    <main className="flex flex-col items-center gap-6 p-6">
-      <ConnectWalletButton
-        onConnect={(prov, sig) => {
-          setProvider(prov);
-          setSigner(sig);
-        }}
-      />
-      <AdminPanel provider={provider} signer={signer} />
-    </main>
-  );
+  return <AdminClient />;
 }

--- a/app/components/AdminClient.tsx
+++ b/app/components/AdminClient.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { useState } from "react";
+import { ethers } from "ethers";
+import ConnectWalletButton from "./ConnectWalletButton";
+import AdminPanel from "./AdminPanel";
+
+export default function AdminClient() {
+  const [provider, setProvider] = useState<ethers.BrowserProvider>();
+  const [signer, setSigner] = useState<ethers.JsonRpcSigner>();
+
+  return (
+    <main className="flex flex-col items-center gap-6 p-6">
+      <ConnectWalletButton
+        onConnect={(prov, sig) => {
+          setProvider(prov);
+          setSigner(sig);
+        }}
+      />
+      <AdminPanel provider={provider} signer={signer} />
+    </main>
+  );
+}

--- a/app/components/HomeClient.tsx
+++ b/app/components/HomeClient.tsx
@@ -1,0 +1,225 @@
+"use client";
+import { useEffect, useState } from "react";
+import { ethers } from "ethers";
+import lotteryAbi from "../../contracts/Bittery.json";
+import InfoCarousel from "./InfoCarousel";
+import ReferralLink from "./ReferralLink";
+import EarningsTable from "./EarningsTable";
+import Link from "next/link";
+
+const CONTRACT_ADDRESS = process.env.NEXT_PUBLIC_CONTRACT_ADDRESS || "";
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const LAUNCH_DATE = new Date("2025-08-05T20:00:00-03:00").getTime();
+
+export default function HomeClient() {
+  const [provider, setProvider] = useState<ethers.BrowserProvider>();
+  const [signer, setSigner] = useState<ethers.JsonRpcSigner>();
+  const [players, setPlayers] = useState<string[]>([]);
+  const [winner, setWinner] = useState<string>("");
+  const [winners, setWinners] = useState<string[]>([]);
+  const [timeLeft, setTimeLeft] = useState<string>("");
+  const [contract, setContract] = useState<ethers.Contract>();
+  const [animate, setAnimate] = useState(false);
+  const [launched, setLaunched] = useState(false);
+  const [launchCountdown, setLaunchCountdown] = useState("");
+
+  useEffect(() => {
+    setAnimate(true);
+  }, []);
+
+  useEffect(() => {
+    const calc = () => {
+      const now = Date.now();
+      const diff = LAUNCH_DATE - now;
+      if (diff <= 0) {
+        setLaunched(true);
+      } else {
+        const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+        const hours = Math.floor(
+          (diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)
+        );
+        const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+        setLaunchCountdown(
+          `${days} days, ${hours} hours and ${minutes} minutes`
+        );
+        setLaunched(false);
+      }
+    };
+    calc();
+    const id = setInterval(calc, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    const calc = () => {
+      const now = new Date();
+      const next = getNextDraw();
+      const diff = next.getTime() - now.getTime();
+      const h = Math.floor(diff / 3600000);
+      const m = Math.floor((diff % 3600000) / 60000);
+      const s = Math.floor((diff % 60000) / 1000);
+      setTimeLeft(`${h}h ${m}m ${s}s`);
+    };
+    calc();
+    const id = setInterval(calc, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    const ref = params.get("ref");
+    if (ref) {
+      localStorage.setItem("referrer", ref);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!provider) return;
+    const c = new ethers.Contract(CONTRACT_ADDRESS, lotteryAbi.abi, provider);
+    setContract(c);
+    getPlayers(c);
+    getWinner(c);
+    getWinners(c);
+    c.on("WinnerPicked", () => {
+      getWinner(c);
+      getWinners(c);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [provider]);
+
+  async function connect() {
+    if ((window as any).ethereum) {
+      const prov = new ethers.BrowserProvider((window as any).ethereum);
+      await prov.send("eth_requestAccounts", []);
+      setProvider(prov);
+      setSigner(await prov.getSigner());
+    }
+  }
+
+  async function buy() {
+    if (!contract || !signer) return;
+    const referrer =
+      (typeof window !== "undefined" && localStorage.getItem("referrer")) ||
+      ZERO_ADDRESS;
+    const tx = await (contract as any)
+      .connect(signer)
+      .buyTicket(referrer, { value: ethers.parseEther("0.01") });
+    await tx.wait();
+    getPlayers(contract);
+  }
+
+  async function getPlayers(c: ethers.Contract) {
+    const list: string[] = await c.getPlayers();
+    setPlayers(list);
+  }
+
+  async function getWinner(c: ethers.Contract) {
+    const w: string = await c.recentWinner();
+    setWinner(w);
+  }
+
+  async function getWinners(c: ethers.Contract) {
+    const list: string[] = await c.getWinners();
+    setWinners(list.slice(-5).reverse());
+  }
+
+  function getNextDraw() {
+    const now = new Date();
+    const next = new Date(now);
+    next.setUTCDate(now.getUTCDate() + ((7 - now.getUTCDay()) % 7));
+    next.setUTCHours(20, 0, 0, 0);
+    if (next <= now) {
+      next.setUTCDate(next.getUTCDate() + 7);
+    }
+    return next;
+  }
+
+  return (
+    <main
+      className={`flex flex-col items-center justify-center w-full px-4 py-12 text-center gap-8 ${
+        animate ? "animate-fade" : ""
+      }`}
+    >
+      <header className="space-y-2">
+        <img
+          src="/Bittery-Logo.png"
+          alt="Bittery Logo"
+          className="mx-auto w-32 h-32"
+        />
+        <h1 className="text-4xl sm:text-5xl font-bold tracking-tight title">
+          Bittery
+        </h1>
+        <Link href={"/terms"} className="text-sm text-gray-500 hover:underline">
+          Terms •
+        </Link>{" "}
+        <Link
+          href={"/privacy"}
+          className="text-sm text-gray-500 hover:underline"
+        >
+          Privacy •
+        </Link>{" "}
+        © 2025 Bittery LLC
+        <p className="text-gray-600 dark:text-gray-400 text-base sm:text-lg">
+          A Decentralized Lottery Powered by Chainlink VRF
+        </p>
+      </header>
+      <div id="status" className="text-lg">
+        {launched
+          ? "🟢 We're already launched! Buy your ticket now!"
+          : `⏳ ${launchCountdown} left until Bittery's launch`}
+      </div>
+      {launched && <p className="text-lg">Next draw in: {timeLeft}</p>}
+      <InfoCarousel />
+      <div className="flex flex-col sm:flex-row gap-4">
+        <button
+          className="rounded bg-black text-white px-6 py-2 hover:bg-gray-800 transition-colors"
+          onClick={connect}
+        >
+          Connect Wallet
+        </button>
+        {launched && (
+          <button
+            id="buy-button"
+            className="rounded border border-gray-800 dark:border-gray-200 px-6 py-2 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            onClick={buy}
+          >
+            Buy Ticket (0.01 ETH)
+          </button>
+        )}
+      </div>
+      {!launched && <EarningsTable />}
+      {launched && <ReferralLink />}
+      <div className="w-full max-w-md text-left">
+        <h2 className="text-xl font-semibold mb-2">
+          Players ({players.length})
+        </h2>
+        <ul className="space-y-1">
+          {players.map((p) => (
+            <li key={p} className="truncate">
+              {p}
+            </li>
+          ))}
+        </ul>
+      </div>
+      {winner && (
+        <div>
+          <h2 className="text-xl font-semibold">Last Winner</h2>
+          <p className="truncate">{winner}</p>
+        </div>
+      )}
+      {winners.length > 0 && (
+        <div className="w-full max-w-md text-left">
+          <h2 className="text-xl font-semibold mb-2">Recent Winners</h2>
+          <ul className="space-y-1">
+            {winners.map((w) => (
+              <li key={w} className="truncate">
+                {w}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/app/components/SimulatorClient.tsx
+++ b/app/components/SimulatorClient.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useState, useMemo, useEffect } from "react";
+
+const ETH_TO_USD = 3000;
+const REF_PERCENT_ETH = 0.00025; // 2.5% of 0.01 ETH
+
+interface RowData {
+  players: number;
+  referrals: number;
+  referralEarningsETH: number;
+  referralEarningsUSD: number;
+  chance: number;
+  prizePoolETH: number;
+  prizePoolUSD: number;
+  totalPotentialUSD: number;
+}
+
+function generateData(): RowData[][] {
+  const groups: RowData[][] = [];
+  let group: RowData[] = [];
+  for (let players = 2; players <= 1000; players++) {
+    const referrals = players - 1;
+    const referralEarningsETH = referrals * REF_PERCENT_ETH;
+    const referralEarningsUSD = referralEarningsETH * ETH_TO_USD;
+    const chance = 1 / players;
+    const prizePoolETH = 0.0095 * players;
+    const prizePoolUSD = prizePoolETH * ETH_TO_USD;
+    const totalPotentialUSD = referralEarningsUSD + prizePoolUSD * chance;
+    group.push({
+      players,
+      referrals,
+      referralEarningsETH,
+      referralEarningsUSD,
+      chance,
+      prizePoolETH,
+      prizePoolUSD,
+      totalPotentialUSD,
+    });
+    if (group.length === 50) {
+      groups.push(group);
+      group = [];
+    }
+  }
+  if (group.length) groups.push(group);
+  return groups;
+}
+
+function useAnimatedNumber(value: number, duration = 400) {
+  const [display, setDisplay] = useState(value);
+  useEffect(() => {
+    const start = display;
+    const startTime = performance.now();
+    let frame: number;
+    const tick = () => {
+      const now = performance.now();
+      const progress = Math.min(1, (now - startTime) / duration);
+      setDisplay(start + (value - start) * progress);
+      if (progress < 1) frame = requestAnimationFrame(tick);
+    };
+    tick();
+    return () => cancelAnimationFrame(frame);
+  }, [value, duration]);
+  return display;
+}
+
+export default function SimulatorClient() {
+  const [weeklyReferrals, setWeeklyReferrals] = useState(0);
+  const groups = useMemo(() => generateData(), []);
+
+  const weeklyETH = weeklyReferrals * REF_PERCENT_ETH;
+  const weeklyUSD = weeklyETH * ETH_TO_USD;
+  const monthlyUSD = weeklyUSD * 4;
+  const yearlyUSD = weeklyUSD * 52;
+
+  const dispWeeklyETH = useAnimatedNumber(weeklyETH);
+  const dispWeeklyUSD = useAnimatedNumber(weeklyUSD);
+  const dispMonthlyUSD = useAnimatedNumber(monthlyUSD);
+  const dispYearlyUSD = useAnimatedNumber(yearlyUSD);
+
+  return (
+    <main className="px-4 py-8 space-y-8 max-w-7xl mx-auto">
+      <div className="space-y-4">
+        <h1 className="text-3xl font-bold title">Referral Earnings Simulator</h1>
+        <div className="flex flex-col sm:flex-row items-center gap-4">
+          <label className="font-medium">
+            Weekly referred players:
+            <input
+              type="number"
+              min={1}
+              max={1000000}
+              value={weeklyReferrals}
+              onChange={(e) => setWeeklyReferrals(Number(e.target.value))}
+              className="ml-2 border rounded p-1 w-32 text-black"
+            />
+          </label>
+        </div>
+        <div className="grid sm:grid-cols-3 gap-4 pt-4">
+          <div className="border rounded p-4 bg-white dark:bg-neutral-900 shadow">
+            <h2 className="font-semibold">Weekly</h2>
+            <p>{dispWeeklyETH.toFixed(6)} ETH</p>
+            <p>$ {dispWeeklyUSD.toFixed(2)}</p>
+          </div>
+          <div className="border rounded p-4 bg-white dark:bg-neutral-900 shadow">
+            <h2 className="font-semibold">Monthly</h2>
+            <p>$ {dispMonthlyUSD.toFixed(2)}</p>
+          </div>
+          <div className="border rounded p-4 bg-white dark:bg-neutral-900 shadow">
+            <h2 className="font-semibold">Yearly</h2>
+            <p>$ {dispYearlyUSD.toFixed(2)}</p>
+          </div>
+        </div>
+      </div>
+      <div className="space-y-4">
+        <h2 className="text-2xl font-bold title">Referral & Prize Table</h2>
+        {groups.map((group, i) => (
+          <div key={i} className="overflow-x-auto">
+            <h3 className="font-semibold my-2">
+              Players {group[0].players}-{group[group.length - 1].players}
+            </h3>
+            <table className="min-w-full text-sm border-collapse border">
+              <thead>
+                <tr>
+                  <th className="border px-2">Players</th>
+                  <th className="border px-2">Referrals</th>
+                  <th className="border px-2">Referral Earnings (ETH)</th>
+                  <th className="border px-2">Referral Earnings ($)</th>
+                  <th className="border px-2">Chance to Win</th>
+                  <th className="border px-2">Prize Pool (ETH)</th>
+                  <th className="border px-2">Prize Pool ($)</th>
+                  <th className="border px-2">Total Potential Gain ($)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {group.map((row) => (
+                  <tr key={row.players}>
+                    <td className="border px-2 text-center">{row.players}</td>
+                    <td className="border px-2 text-center">{row.referrals}</td>
+                    <td className="border px-2 text-right">
+                      {row.referralEarningsETH.toFixed(6)}
+                    </td>
+                    <td className="border px-2 text-right">
+                      {row.referralEarningsUSD.toFixed(2)}
+                    </td>
+                    <td className="border px-2 text-right">
+                      {row.chance.toFixed(4)}
+                    </td>
+                    <td className="border px-2 text-right">
+                      {row.prizePoolETH.toFixed(6)}
+                    </td>
+                    <td className="border px-2 text-right">
+                      {row.prizePoolUSD.toFixed(2)}
+                    </td>
+                    <td className="border px-2 text-right">
+                      {row.totalPotentialUSD.toFixed(2)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,8 +15,30 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Bittery",
+  metadataBase: new URL("https://bittery.org"),
+  title: {
+    default: "Bittery",
+    template: "%s | Bittery",
+  },
   description: "Decentralized lottery game",
+  openGraph: {
+    title: "Bittery",
+    description: "Decentralized lottery game",
+    url: "https://bittery.org",
+    siteName: "Bittery",
+    images: ["/Bittery-Logo.png"],
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Bittery",
+    description: "Decentralized lottery game",
+    images: ["/Bittery-Logo.png"],
+  },
+  icons: {
+    icon: "/favicon.ico",
+  },
 };
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,225 +1,26 @@
-"use client";
-import { useEffect, useState } from "react";
-import { ethers } from "ethers";
-import lotteryAbi from "../contracts/Bittery.json";
-import InfoCarousel from "./components/InfoCarousel";
-import ReferralLink from "./components/ReferralLink";
-import EarningsTable from "./components/EarningsTable";
-import Link from "next/link";
+import type { Metadata } from "next";
+import HomeClient from "./components/HomeClient";
 
-const CONTRACT_ADDRESS = process.env.NEXT_PUBLIC_CONTRACT_ADDRESS || "";
-const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
-const LAUNCH_DATE = new Date("2025-08-05T20:00:00-03:00").getTime();
+export const metadata: Metadata = {
+  title: "Home",
+  description:
+    "Play the Bittery decentralized lottery. Connect your wallet and buy tickets for a chance to win.",
+  openGraph: {
+    title: "Bittery Lottery",
+    description:
+      "Play the Bittery decentralized lottery. Connect your wallet and buy tickets for a chance to win.",
+    images: ["/Bittery-Logo.png"],
+    url: "https://bittery.org/",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Bittery Lottery",
+    description:
+      "Play the Bittery decentralized lottery. Connect your wallet and buy tickets for a chance to win.",
+    images: ["/Bittery-Logo.png"],
+  },
+};
 
 export default function Home() {
-  const [provider, setProvider] = useState<ethers.BrowserProvider>();
-  const [signer, setSigner] = useState<ethers.JsonRpcSigner>();
-  const [players, setPlayers] = useState<string[]>([]);
-  const [winner, setWinner] = useState<string>("");
-  const [winners, setWinners] = useState<string[]>([]);
-  const [timeLeft, setTimeLeft] = useState<string>("");
-  const [contract, setContract] = useState<ethers.Contract>();
-  const [animate, setAnimate] = useState(false);
-  const [launched, setLaunched] = useState(false);
-  const [launchCountdown, setLaunchCountdown] = useState("");
-
-  useEffect(() => {
-    setAnimate(true);
-  }, []);
-
-  useEffect(() => {
-    const calc = () => {
-      const now = Date.now();
-      const diff = LAUNCH_DATE - now;
-      if (diff <= 0) {
-        setLaunched(true);
-      } else {
-        const days = Math.floor(diff / (1000 * 60 * 60 * 24));
-        const hours = Math.floor(
-          (diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)
-        );
-        const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
-        setLaunchCountdown(
-          `${days} days, ${hours} hours and ${minutes} minutes`
-        );
-        setLaunched(false);
-      }
-    };
-    calc();
-    const id = setInterval(calc, 1000);
-    return () => clearInterval(id);
-  }, []);
-
-  useEffect(() => {
-    const calc = () => {
-      const now = new Date();
-      const next = getNextDraw();
-      const diff = next.getTime() - now.getTime();
-      const h = Math.floor(diff / 3600000);
-      const m = Math.floor((diff % 3600000) / 60000);
-      const s = Math.floor((diff % 60000) / 1000);
-      setTimeLeft(`${h}h ${m}m ${s}s`);
-    };
-    calc();
-    const id = setInterval(calc, 1000);
-    return () => clearInterval(id);
-  }, []);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const params = new URLSearchParams(window.location.search);
-    const ref = params.get("ref");
-    if (ref) {
-      localStorage.setItem("referrer", ref);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!provider) return;
-    const c = new ethers.Contract(CONTRACT_ADDRESS, lotteryAbi.abi, provider);
-    setContract(c);
-    getPlayers(c);
-    getWinner(c);
-    getWinners(c);
-    c.on("WinnerPicked", () => {
-      getWinner(c);
-      getWinners(c);
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [provider]);
-
-  async function connect() {
-    if ((window as any).ethereum) {
-      const prov = new ethers.BrowserProvider((window as any).ethereum);
-      await prov.send("eth_requestAccounts", []);
-      setProvider(prov);
-      setSigner(await prov.getSigner());
-    }
-  }
-
-  async function buy() {
-    if (!contract || !signer) return;
-    const referrer =
-      (typeof window !== "undefined" && localStorage.getItem("referrer")) ||
-      ZERO_ADDRESS;
-    const tx = await (contract as any)
-      .connect(signer)
-      .buyTicket(referrer, { value: ethers.parseEther("0.01") });
-    await tx.wait();
-    getPlayers(contract);
-  }
-
-  async function getPlayers(c: ethers.Contract) {
-    const list: string[] = await c.getPlayers();
-    setPlayers(list);
-  }
-
-  async function getWinner(c: ethers.Contract) {
-    const w: string = await c.recentWinner();
-    setWinner(w);
-  }
-
-  async function getWinners(c: ethers.Contract) {
-    const list: string[] = await c.getWinners();
-    setWinners(list.slice(-5).reverse());
-  }
-
-  function getNextDraw() {
-    const now = new Date();
-    const next = new Date(now);
-    next.setUTCDate(now.getUTCDate() + ((7 - now.getUTCDay()) % 7));
-    next.setUTCHours(20, 0, 0, 0);
-    if (next <= now) {
-      next.setUTCDate(next.getUTCDate() + 7);
-    }
-    return next;
-  }
-
-  return (
-    <main
-      className={`flex flex-col items-center justify-center w-full px-4 py-12 text-center gap-8 ${
-        animate ? "animate-fade" : ""
-      }`}
-    >
-      <header className="space-y-2">
-        <img
-          src="/bittery-alpha.png"
-          alt="Bittery Lottery"
-          className="mx-auto w-32 h-32"
-        />
-        <h1 className="text-4xl sm:text-5xl font-bold tracking-tight title">
-          Bittery
-        </h1>
-        <Link href={"/terms"} className="text-sm text-gray-500 hover:underline">
-          Terms •
-        </Link>{" "}
-        <Link
-          href={"/privacy"}
-          className="text-sm text-gray-500 hover:underline"
-        >
-          Privacy •
-        </Link>{" "}
-        © 2025 Bittery LLC
-        <p className="text-gray-600 dark:text-gray-400 text-base sm:text-lg">
-          A Decentralized Lottery Powered by Chainlink VRF
-        </p>
-      </header>
-      <div id="status" className="text-lg">
-        {launched
-          ? "🟢 We're already launched! Buy your ticket now!"
-          : `⏳ ${launchCountdown} left until Bittery's launch`}
-      </div>
-      {launched && <p className="text-lg">Next draw in: {timeLeft}</p>}
-      <InfoCarousel />
-      <div className="flex flex-col sm:flex-row gap-4">
-        <button
-          className="rounded bg-black text-white px-6 py-2 hover:bg-gray-800 transition-colors"
-          onClick={connect}
-        >
-          Connect Wallet
-        </button>
-        {launched && (
-          <button
-            id="buy-button"
-            className="rounded border border-gray-800 dark:border-gray-200 px-6 py-2 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-            onClick={buy}
-          >
-            Buy Ticket (0.01 ETH)
-          </button>
-        )}
-      </div>
-      {!launched && <EarningsTable />}
-      {launched && <ReferralLink />}
-      <div className="w-full max-w-md text-left">
-        <h2 className="text-xl font-semibold mb-2">
-          Players ({players.length})
-        </h2>
-        <ul className="space-y-1">
-          {players.map((p) => (
-            <li key={p} className="truncate">
-              {p}
-            </li>
-          ))}
-        </ul>
-      </div>
-      {winner && (
-        <div>
-          <h2 className="text-xl font-semibold">Last Winner</h2>
-          <p className="truncate">{winner}</p>
-        </div>
-      )}
-      {winners.length > 0 && (
-        <div className="w-full max-w-md text-left">
-          <h2 className="text-xl font-semibold mb-2">Recent Winners</h2>
-          <ul className="space-y-1">
-            {winners.map((w) => (
-              <li key={w} className="truncate">
-                {w}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-    </main>
-  );
+  return <HomeClient />;
 }

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,6 +1,18 @@
 export const metadata = {
   title: "Privacy Policy",
   description: "Privacy policy for using the Bittery platform",
+  openGraph: {
+    title: "Privacy Policy",
+    description: "Privacy policy for using the Bittery platform",
+    images: ["/Bittery-Logo.png"],
+    url: "https://bittery.org/privacy",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Privacy Policy",
+    description: "Privacy policy for using the Bittery platform",
+    images: ["/Bittery-Logo.png"],
+  },
 };
 import Link from "next/link";
 

--- a/app/simulator/page.tsx
+++ b/app/simulator/page.tsx
@@ -1,166 +1,23 @@
-"use client";
+import type { Metadata } from "next";
+import SimulatorClient from "../components/SimulatorClient";
 
-import { useState, useMemo, useEffect } from "react";
-
-const ETH_TO_USD = 3000;
-const REF_PERCENT_ETH = 0.00025; // 2.5% of 0.01 ETH
-
-interface RowData {
-  players: number;
-  referrals: number;
-  referralEarningsETH: number;
-  referralEarningsUSD: number;
-  chance: number;
-  prizePoolETH: number;
-  prizePoolUSD: number;
-  totalPotentialUSD: number;
-}
-
-function generateData(): RowData[][] {
-  const groups: RowData[][] = [];
-  let group: RowData[] = [];
-  for (let players = 2; players <= 1000; players++) {
-    const referrals = players - 1;
-    const referralEarningsETH = referrals * REF_PERCENT_ETH;
-    const referralEarningsUSD = referralEarningsETH * ETH_TO_USD;
-    const chance = 1 / players;
-    const prizePoolETH = 0.0095 * players;
-    const prizePoolUSD = prizePoolETH * ETH_TO_USD;
-    const totalPotentialUSD = referralEarningsUSD + prizePoolUSD * chance;
-    group.push({
-      players,
-      referrals,
-      referralEarningsETH,
-      referralEarningsUSD,
-      chance,
-      prizePoolETH,
-      prizePoolUSD,
-      totalPotentialUSD,
-    });
-    if (group.length === 50) {
-      groups.push(group);
-      group = [];
-    }
-  }
-  if (group.length) groups.push(group);
-  return groups;
-}
-
-function useAnimatedNumber(value: number, duration = 400) {
-  const [display, setDisplay] = useState(value);
-  useEffect(() => {
-    const start = display;
-    const startTime = performance.now();
-    let frame: number;
-    const tick = () => {
-      const now = performance.now();
-      const progress = Math.min(1, (now - startTime) / duration);
-      setDisplay(start + (value - start) * progress);
-      if (progress < 1) frame = requestAnimationFrame(tick);
-    };
-    tick();
-    return () => cancelAnimationFrame(frame);
-  }, [value, duration]);
-  return display;
-}
+export const metadata: Metadata = {
+  title: "Referral Simulator",
+  description: "Simulate potential earnings from Bittery's referral program",
+  openGraph: {
+    title: "Referral Simulator",
+    description: "Simulate potential earnings from Bittery's referral program",
+    images: ["/Bittery-Logo.png"],
+    url: "https://bittery.org/simulator",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Referral Simulator",
+    description: "Simulate potential earnings from Bittery's referral program",
+    images: ["/Bittery-Logo.png"],
+  },
+};
 
 export default function SimulatorPage() {
-  const [weeklyReferrals, setWeeklyReferrals] = useState(0);
-  const groups = useMemo(() => generateData(), []);
-
-  const weeklyETH = weeklyReferrals * REF_PERCENT_ETH;
-  const weeklyUSD = weeklyETH * ETH_TO_USD;
-  const monthlyUSD = weeklyUSD * 4;
-  const yearlyUSD = weeklyUSD * 52;
-
-  const dispWeeklyETH = useAnimatedNumber(weeklyETH);
-  const dispWeeklyUSD = useAnimatedNumber(weeklyUSD);
-  const dispMonthlyUSD = useAnimatedNumber(monthlyUSD);
-  const dispYearlyUSD = useAnimatedNumber(yearlyUSD);
-
-  return (
-    <main className="px-4 py-8 space-y-8 max-w-7xl mx-auto">
-      <div className="space-y-4">
-        <h1 className="text-3xl font-bold title">Referral Earnings Simulator</h1>
-        <div className="flex flex-col sm:flex-row items-center gap-4">
-          <label className="font-medium">
-            Weekly referred players:
-            <input
-              type="number"
-              min={1}
-              max={1000000}
-              value={weeklyReferrals}
-              onChange={(e) => setWeeklyReferrals(Number(e.target.value))}
-              className="ml-2 border rounded p-1 w-32 text-black"
-            />
-          </label>
-        </div>
-        <div className="grid sm:grid-cols-3 gap-4 pt-4">
-          <div className="border rounded p-4 bg-white dark:bg-neutral-900 shadow">
-            <h2 className="font-semibold">Weekly</h2>
-            <p>{dispWeeklyETH.toFixed(6)} ETH</p>
-            <p>$ {dispWeeklyUSD.toFixed(2)}</p>
-          </div>
-          <div className="border rounded p-4 bg-white dark:bg-neutral-900 shadow">
-            <h2 className="font-semibold">Monthly</h2>
-            <p>$ {dispMonthlyUSD.toFixed(2)}</p>
-          </div>
-          <div className="border rounded p-4 bg-white dark:bg-neutral-900 shadow">
-            <h2 className="font-semibold">Yearly</h2>
-            <p>$ {dispYearlyUSD.toFixed(2)}</p>
-          </div>
-        </div>
-      </div>
-      <div className="space-y-4">
-        <h2 className="text-2xl font-bold title">Referral & Prize Table</h2>
-        {groups.map((group, i) => (
-          <div key={i} className="overflow-x-auto">
-            <h3 className="font-semibold my-2">
-              Players {group[0].players}-{group[group.length - 1].players}
-            </h3>
-            <table className="min-w-full text-sm border-collapse border">
-              <thead>
-                <tr>
-                  <th className="border px-2">Players</th>
-                  <th className="border px-2">Referrals</th>
-                  <th className="border px-2">Referral Earnings (ETH)</th>
-                  <th className="border px-2">Referral Earnings ($)</th>
-                  <th className="border px-2">Chance to Win</th>
-                  <th className="border px-2">Prize Pool (ETH)</th>
-                  <th className="border px-2">Prize Pool ($)</th>
-                  <th className="border px-2">Total Potential Gain ($)</th>
-                </tr>
-              </thead>
-              <tbody>
-                {group.map((row) => (
-                  <tr key={row.players}>
-                    <td className="border px-2 text-center">{row.players}</td>
-                    <td className="border px-2 text-center">{row.referrals}</td>
-                    <td className="border px-2 text-right">
-                      {row.referralEarningsETH.toFixed(6)}
-                    </td>
-                    <td className="border px-2 text-right">
-                      {row.referralEarningsUSD.toFixed(2)}
-                    </td>
-                    <td className="border px-2 text-right">
-                      {row.chance.toFixed(4)}
-                    </td>
-                    <td className="border px-2 text-right">
-                      {row.prizePoolETH.toFixed(6)}
-                    </td>
-                    <td className="border px-2 text-right">
-                      {row.prizePoolUSD.toFixed(2)}
-                    </td>
-                    <td className="border px-2 text-right">
-                      {row.totalPotentialUSD.toFixed(2)}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        ))}
-      </div>
-    </main>
-  );
+  return <SimulatorClient />;
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,6 +1,18 @@
 export const metadata = {
   title: "Terms of Use",
   description: "Terms of service for using the Bittery platform",
+  openGraph: {
+    title: "Terms of Use",
+    description: "Terms of service for using the Bittery platform",
+    images: ["/Bittery-Logo.png"],
+    url: "https://bittery.org/terms",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Terms of Use",
+    description: "Terms of service for using the Bittery platform",
+    images: ["/Bittery-Logo.png"],
+  },
 };
 import Link from "next/link";
 


### PR DESCRIPTION
## Summary
- add global SEO metadata in root layout
- create server pages with SEO metadata for each page
- use new HomeClient, AdminClient and SimulatorClient components
- update pages to use Bittery logo image

## Testing
- `npm run build`
- `npm test` *(fails: VM Exception while processing transaction)*

------
https://chatgpt.com/codex/tasks/task_e_6870159a4e10832f863a6362bf297156