### PR TITLE
Add next-intl based i18n

### DIFF
--- a/app/[locale]/admin/page.tsx
+++ b/app/[locale]/admin/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import AdminClient from "../components/AdminClient";
+import AdminClient from "../../components/AdminClient";
 
 export const metadata: Metadata = {
   title: "Admin",

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,8 +1,13 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import TermsBanner from "./components/TermsBanner";
-import Footer from "./components/Footer";
-import "./globals.css";
+import TermsBanner from "../components/TermsBanner";
+import Footer from "../components/Footer";
+import "../globals.css";
+
+import {NextIntlClientProvider, useMessages} from "next-intl";
+import {unstable_setRequestLocale} from "next-intl/server";
+import {locales} from "../../i18n";
+import { notFound } from "next/navigation";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -41,19 +46,30 @@ export const metadata: Metadata = {
   },
 };
 
+export function generateStaticParams() {
+  return locales.map((locale) => ({ locale }));
+}
+
 export default function RootLayout({
   children,
+  params: { locale },
 }: Readonly<{
   children: React.ReactNode;
+  params: { locale: string };
 }>) {
+  if (!locales.includes(locale as any)) notFound();
+  unstable_setRequestLocale(locale);
+  const messages = useMessages();
   return (
-    <html lang="en">
+    <html lang={locale}>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gradient-to-br from-white to-gray-100 dark:from-neutral-900 dark:to-neutral-800 text-gray-900 dark:text-gray-100 flex flex-col min-h-screen`}
       >
-        <main className="flex-grow">{children}</main>
-        <Footer />
-        <TermsBanner />
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          <main className="flex-grow">{children}</main>
+          <Footer />
+          <TermsBanner />
+        </NextIntlClientProvider>
       </body>
     </html>
   );

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import HomeClient from "./components/HomeClient";
+import HomeClient from "../components/HomeClient";
 
 export const metadata: Metadata = {
   title: "Home",

--- a/app/[locale]/privacy/page.tsx
+++ b/app/[locale]/privacy/page.tsx
@@ -49,7 +49,7 @@ export default function PrivacyPage() {
 
       <p className="mt-8 text-sm text-gray-500">Last updated: July 10, 2025</p>
       <Link
-        href="/"
+        href="../"
         className="text-blue-600 hover:underline mt-4 inline-block title"
       >
         Back to Home

--- a/app/[locale]/simulator/page.tsx
+++ b/app/[locale]/simulator/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import SimulatorClient from "../components/SimulatorClient";
+import SimulatorClient from "../../components/SimulatorClient";
 
 export const metadata: Metadata = {
   title: "Referral Simulator",

--- a/app/[locale]/terms/page.tsx
+++ b/app/[locale]/terms/page.tsx
@@ -48,7 +48,7 @@ export default function TermsPage() {
 
       <p className="mt-8 text-sm text-gray-500">Last updated: July 10, 2025</p>
       <Link
-        href="/"
+        href="../"
         className="text-blue-600 hover:underline mt-4 inline-block title"
       >
         Back to Home

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,11 +1,14 @@
 // components/Footer.tsx
+import LanguageSwitcher from "./LanguageSwitcher";
+
 export default function Footer() {
   return (
-    <footer className="w-full bg-zinc-900 text-center py-4 border-t border-zinc-800">
+    <footer className="w-full bg-zinc-900 text-center py-4 border-t border-zinc-800 flex items-center justify-center gap-4">
       <p className="text-sm text-zinc-400">
         All rights reserved © 2025,{" "}
         <span className="font-semibold text-white">Bittery LLC</span>
       </p>
+      <LanguageSwitcher />
     </footer>
   );
 }

--- a/app/components/HomeClient.tsx
+++ b/app/components/HomeClient.tsx
@@ -6,6 +6,7 @@ import InfoCarousel from "./InfoCarousel";
 import ReferralLink from "./ReferralLink";
 import EarningsTable from "./EarningsTable";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 
 const CONTRACT_ADDRESS = process.env.NEXT_PUBLIC_CONTRACT_ADDRESS || "";
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
@@ -22,6 +23,7 @@ export default function HomeClient() {
   const [animate, setAnimate] = useState(false);
   const [launched, setLaunched] = useState(false);
   const [launchCountdown, setLaunchCountdown] = useState("");
+  const t = useTranslations("common");
 
   useEffect(() => {
     setAnimate(true);
@@ -147,14 +149,14 @@ export default function HomeClient() {
           alt="Bittery Logo"
           className="mx-auto w-32 h-32"
         />
-        {/* <h1 className="text-4xl sm:text-5xl font-bold tracking-tight title">
-          Bittery
-        </h1> */}
-        <Link href={"/terms"} className="text-sm text-gray-500 hover:underline">
+        <h1 className="text-4xl sm:text-5xl font-bold tracking-tight title">
+          {t("title")}
+        </h1>
+        <Link href={"terms"} className="text-sm text-gray-500 hover:underline">
           Terms •
         </Link>{" "}
         <Link
-          href={"/privacy"}
+          href={"privacy"}
           className="text-sm text-gray-500 hover:underline"
         >
           Privacy •

--- a/app/components/LanguageSwitcher.tsx
+++ b/app/components/LanguageSwitcher.tsx
@@ -1,0 +1,25 @@
+"use client";
+import {useRouter, usePathname, useLocale} from 'next-intl/client';
+
+export default function LanguageSwitcher() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const locale = useLocale();
+
+  const changeLocale = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const next = e.target.value;
+    document.cookie = `NEXT_LOCALE=${next}; path=/`;
+    router.replace(pathname, {locale: next});
+  };
+
+  return (
+    <select
+      onChange={changeLocale}
+      value={locale}
+      className="bg-zinc-800 text-white text-sm rounded p-1"
+    >
+      <option value="en">EN</option>
+      <option value="pt">PT</option>
+    </select>
+  );
+}

--- a/app/components/TermsBanner.tsx
+++ b/app/components/TermsBanner.tsx
@@ -25,14 +25,14 @@ export default function TermsBanner() {
         <p className="text-sm">
           By using this site, you agree to our{" "}
           <a
-            href="/terms"
+            href="terms"
             className="underline text-blue-400 hover:text-blue-300 title"
           >
             Terms
           </a>{" "}
           and{" "}
           <a
-            href="/privacy"
+            href="privacy"
             className="underline text-blue-400 hover:text-blue-300 title"
           >
             Privacy Policy

--- a/i18n.ts
+++ b/i18n.ts
@@ -1,0 +1,9 @@
+export const locales = ['en', 'pt'] as const;
+export const defaultLocale = 'en';
+export const localePrefix = 'always';
+
+import {getRequestConfig} from 'next-intl/server';
+
+export default getRequestConfig(async ({locale}) => ({
+  messages: (await import(`./locales/${locale}/common.json`)).default,
+}));

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1,0 +1,1 @@
+{ "title": "Decentralized Lottery" }

--- a/locales/pt/common.json
+++ b/locales/pt/common.json
@@ -1,0 +1,1 @@
+{ "title": "Loteria Descentralizada" }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,12 @@
+import createMiddleware from 'next-intl/middleware';
+import {locales, defaultLocale, localePrefix} from './i18n';
+
+export default createMiddleware({
+  locales,
+  defaultLocale,
+  localePrefix,
+});
+
+export const config = {
+  matcher: ['/', '/((?!_next|.*\..*).*)'],
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  i18n: {
+    locales: ["en", "pt"],
+    defaultLocale: "en",
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@openzeppelin/contracts": "^5.3.0",
         "ethers": "^6.15.0",
         "next": "15.3.5",
+        "next-intl": "^4.3.4",
         "node-cron": "^3.0.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -1602,6 +1603,66 @@
         "node": ">=14"
       }
     },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
+      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.1",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
+      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
+      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/icu-skeleton-parser": "1.8.14",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
+      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.10.tgz",
+      "integrity": "sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
+      }
+    },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.34.2",
       "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.2.tgz",
@@ -2995,6 +3056,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+      "license": "MIT"
     },
     "node_modules/@scroll-tech/contracts": {
       "version": "0.1.0",
@@ -4936,6 +5003,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
@@ -6656,6 +6729,18 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.16",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
+      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/io-ts": {
       "version": "1.10.4",
       "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-1.10.4.tgz",
@@ -7836,6 +7921,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -7894,6 +7988,33 @@
           "optional": true
         },
         "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.3.4.tgz",
+      "integrity": "sha512-VWLIDlGbnL/o4LnveJTJD1NOYN8lh3ZAGTWw2krhfgg53as3VsS4jzUVnArJdqvwtlpU/2BIDbWTZ7V4o1jFEw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.5.4",
+        "negotiator": "^1.0.0",
+        "use-intl": "^4.3.4"
+      },
+      "peerDependencies": {
+        "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0",
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
           "optional": true
         }
       }
@@ -10521,7 +10642,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -10594,6 +10715,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/use-intl": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.3.4.tgz",
+      "integrity": "sha512-sHfiU0QeJ1rirNWRxvCyvlSh9+NczcOzRnPyMeo2rtHXhVnBsvMRjE+UG4eh3lRhCxrvcqei/I0lBxsc59on1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^2.2.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "intl-messageformat": "^10.5.14"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
     "node_modules/utf8": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@openzeppelin/contracts": "^5.3.0",
     "ethers": "^6.15.0",
     "next": "15.3.5",
+    "next-intl": "^4.3.4",
     "node-cron": "^3.0.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"


### PR DESCRIPTION
## Summary
- set up i18n using next-intl
- add language middleware
- organize pages under `[locale]`
- add `LanguageSwitcher` component
- update footer and links
- provide English and Portuguese translations

## Testing
- `npm test` *(fails: VM Exception while processing transaction)*

------
https://chatgpt.com/codex/tasks/task_e_687031f8b0e0832fb5cfdad0184eec3f