### PR TITLE
Fix next-intl imports for app router

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -5,7 +5,7 @@ import Footer from "../components/Footer";
 import "../globals.css";
 
 import {NextIntlClientProvider, useMessages} from "next-intl";
-import {unstable_setRequestLocale} from "next-intl/server";
+import {setRequestLocale} from "next-intl/server";
 import {locales} from "../../i18n";
 import { notFound } from "next/navigation";
 
@@ -53,12 +53,9 @@ export function generateStaticParams() {
 export default function RootLayout({
   children,
   params: { locale },
-}: Readonly<{
-  children: React.ReactNode;
-  params: { locale: string };
-}>) {
+}: any) {
   if (!locales.includes(locale as any)) notFound();
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
   const messages = useMessages();
   return (
     <html lang={locale}>

--- a/app/components/LanguageSwitcher.tsx
+++ b/app/components/LanguageSwitcher.tsx
@@ -1,5 +1,6 @@
 "use client";
-import {useRouter, usePathname, useLocale} from 'next-intl/navigation';
+import {useRouter, usePathname} from '../../navigation';
+import {useLocale} from 'next-intl';
 
 export default function LanguageSwitcher() {
   const router = useRouter();

--- a/i18n.ts
+++ b/i18n.ts
@@ -6,4 +6,5 @@ import {getRequestConfig} from 'next-intl/server';
 
 export default getRequestConfig(async ({locale}) => ({
   messages: (await import(`./locales/${locale}/common.json`)).default,
+  locale: locale || defaultLocale,
 }));

--- a/navigation.ts
+++ b/navigation.ts
@@ -1,0 +1,4 @@
+import {createNavigation} from 'next-intl/navigation';
+import {routing} from './routing';
+
+export const {Link, useRouter, usePathname} = createNavigation(routing);

--- a/routing.ts
+++ b/routing.ts
@@ -1,0 +1,8 @@
+import {defineRouting} from 'next-intl/routing';
+import {locales, defaultLocale, localePrefix} from './i18n';
+
+export const routing = defineRouting({
+  locales,
+  defaultLocale,
+  localePrefix,
+});


### PR DESCRIPTION
## Summary
- update `layout` to use stable `setRequestLocale`
- create routing and navigation helpers for next-intl
- fix `LanguageSwitcher` imports
- adjust i18n config for `getRequestConfig`

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run build` *(fails: export-path-mismatch errors)*

------
https://chatgpt.com/codex/tasks/task_e_68703a6f41d0832f8ca0884580384921