### PR TITLE
Fix translation type for fee percent

### DIFF
--- a/app/components/AdminPanel.tsx
+++ b/app/components/AdminPanel.tsx
@@ -115,7 +115,7 @@ export default function AdminPanel({ provider, signer }: Props) {
       {showPanel && (
         <div className="space-y-6 max-w-md">
           <div className="space-y-1">
-            <div>{t("currentFeePercent", { value: currentFeePercent })}</div>
+            <div>{t("currentFeePercent", { value: currentFeePercent ?? 0 })}</div>
             <input
               type="number"
               value={feePercent}


### PR DESCRIPTION
## Summary
- fix type mismatch in AdminPanel translation call

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68709bcac870832fbca0820be33f5a5b