### PR TITLE
Fix InfoCarousel text overflow

### DIFF
--- a/app/components/InfoCarousel.tsx
+++ b/app/components/InfoCarousel.tsx
@@ -44,11 +44,9 @@ export default function InfoCarousel() {
           ›
         </button>
       </div>
-      <pre>
-        <p className="text-gray-700 dark:text-gray-300 text-left">
+        <p className="text-gray-700 dark:text-gray-300 text-left break-words">
           {slide.text}
         </p>
-      </pre>
       <p className="text-gray-600 dark:text-gray-400 text-sm">
         {slide.link && (
           <a


### PR DESCRIPTION
## Summary
- ensure carousel text breaks lines instead of overflowing container

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run test` *(fails: ZeroAddress revert in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68709e325a98832f81e76aa10bb70767