### PR TITLE
Fix language links to preserve locale

### DIFF
--- a/app/components/HomeClient.tsx
+++ b/app/components/HomeClient.tsx
@@ -6,7 +6,7 @@ import InfoCarousel from "./InfoCarousel";
 import ReferralLink from "./ReferralLink";
 import EarningsTable from "./EarningsTable";
 import Link from "next/link";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 
 const CONTRACT_ADDRESS = process.env.NEXT_PUBLIC_CONTRACT_ADDRESS || "";
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
@@ -24,6 +24,7 @@ export default function HomeClient() {
   const [launched, setLaunched] = useState(false);
   const [launchCountdown, setLaunchCountdown] = useState("");
   const t = useTranslations("common");
+  const locale = useLocale();
 
   useEffect(() => {
     setAnimate(true);
@@ -153,13 +154,13 @@ export default function HomeClient() {
           {t("title")}
         </h1>
         <Link
-          href={`${t("locale")}/${"terms"}`}
+          href={`/${locale}/terms`}
           className="text-sm text-gray-500 hover:underline"
         >
           {t("terms")} •
         </Link>{" "}
         <Link
-          href={`${t("locale")}/${"privacy"}`}
+          href={`/${locale}/privacy`}
           className="text-sm text-gray-500 hover:underline"
         >
           {t("privacyPolicy")} •

--- a/app/components/TermsBanner.tsx
+++ b/app/components/TermsBanner.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
+import Link from "next/link";
 
 const TERMS_VERSION = "2025-07-10"; // Atualize esta versão quando mudar os termos
 
 export default function TermsBanner() {
   const [accepted, setAccepted] = useState<boolean>(true);
   const t = useTranslations("common");
+  const locale = useLocale();
 
   useEffect(() => {
     const savedVersion = localStorage.getItem("termsVersionAccepted");
@@ -26,19 +28,19 @@ export default function TermsBanner() {
       <div className="max-w-4xl mx-auto flex flex-col md:flex-row justify-between items-center gap-4">
         <p className="text-sm">
           {t("agreeTerms")} {" "}
-          <a
-            href="terms"
+          <Link
+            href={`/${locale}/terms`}
             className="underline text-blue-400 hover:text-blue-300 title"
           >
             {t("terms")}
-          </a>{" "}
+          </Link>{" "}
           {t("and") ?? "and"} {" "}
-          <a
-            href="privacy"
+          <Link
+            href={`/${locale}/privacy`}
             className="underline text-blue-400 hover:text-blue-300 title"
           >
             {t("privacyPolicy")}
-          </a>
+          </Link>
           .
         </p>
         <button


### PR DESCRIPTION
## Summary
- ensure home links use the active locale
- ensure terms banner links include locale

## Testing
- `npm test` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870ae582984832fb45e28f6e71ec77d