### PR TITLE
Fix dev script and add development docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ Share your referral link (?ref=YOUR_ADDRESS) and earn a portion of the fee whene
 
 ---
 
+## 🤖 Local Development
+
+Start the Next.js development server with:
+
+```bash
+npm run dev
+```
+
+Avoid using the `--turbopack` flag since the i18n setup is not compatible with it.
+
+---
+
 ## 📤 Deployment Instructions
 
 Ensure you have a `.env` file with the following variables:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
## Summary
- remove `--turbopack` from the dev script so Next.js i18n works correctly
- document how to start the dev server without turbopack

## Testing
- `npm test` *(fails: ZeroAddress error during Hardhat tests)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6870b0bcb758832f8d7a670f3accf1b7