### PR TITLE
Fix i18n layout for Next.js 15

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -4,8 +4,8 @@ import TermsBanner from "../components/TermsBanner";
 import Footer from "../components/Footer";
 import "../globals.css";
 
-import {NextIntlClientProvider, useMessages} from "next-intl";
-import {setRequestLocale} from "next-intl/server";
+import {NextIntlClientProvider} from "next-intl";
+import {setRequestLocale, getMessages} from "next-intl/server";
 import {locales} from "../../i18n";
 import { notFound } from "next/navigation";
 
@@ -50,13 +50,14 @@ export function generateStaticParams() {
   return locales.map((locale) => ({ locale }));
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
-  params: { locale },
+  params,
 }: any) {
+  const {locale} = await params;
   if (!locales.includes(locale as any)) notFound();
   setRequestLocale(locale);
-  const messages = useMessages();
+  const messages = await getMessages();
   return (
     <html lang={locale}>
       <body


### PR DESCRIPTION
## Summary
- use async params and getMessages to comply with latest next-intl

## Testing
- `npm test` *(fails: VM Exception while processing transaction)*
- `npm run lint` *(prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6870b537c9d0832fa3dc00f7521d4006