### PR TITLE
Fix wagmi public provider import

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -10,7 +10,7 @@ import {
   createConfig,
 } from "wagmi";
 import { polygon, polygonMumbai } from "wagmi/chains";
-import { publicProvider } from "wagmi/providers/public";
+import { http } from "wagmi";
 import { RainbowKitProvider, getDefaultWallets } from "@rainbow-me/rainbowkit";
 
 import {NextIntlClientProvider} from "next-intl";
@@ -30,7 +30,7 @@ const geistMono = Geist_Mono({
 
 const { chains, publicClient } = configureChains(
   [polygon, polygonMumbai],
-  [publicProvider()]
+  [http()]
 );
 const { connectors } = getDefaultWallets({
   appName: "Bittery",


### PR DESCRIPTION
## Summary
- import `http` from `wagmi` and use it when configuring chains

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6870d4199c3c832f9930139be167a50a