### PR TITLE
Fix locale links

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import Link from "next/link";
+import { Link } from "../../navigation";
 import { useTranslations } from "next-intl";
 
 export const metadata: Metadata = {
@@ -29,13 +29,13 @@ export default function Home() {
       <h1 className="text-2xl font-bold">{t("selectNetwork")}</h1>
       <div className="flex gap-4">
         <Link
-          href="./test"
+          href="/test"
           className="rounded border px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-800"
         >
           Testnet
         </Link>
         <Link
-          href="./main"
+          href="/main"
           className="rounded border px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-800"
         >
           Mainnet

--- a/app/[locale]/privacy/page.tsx
+++ b/app/[locale]/privacy/page.tsx
@@ -14,7 +14,7 @@ export const metadata = {
     images: ["/Bittery-Logo.png"],
   },
 };
-import Link from "next/link";
+import { Link } from "../../../navigation";
 import { useTranslations } from "next-intl";
 
 export default function PrivacyPage() {
@@ -46,7 +46,7 @@ export default function PrivacyPage() {
 
       <p className="mt-8 text-sm text-gray-500">{t("lastUpdated", { date: "July 10, 2025" })}</p>
       <Link
-        href="../"
+        href="/"
         className="text-blue-600 hover:underline mt-4 inline-block title"
       >
         {t("backToHome")}

--- a/app/[locale]/terms/page.tsx
+++ b/app/[locale]/terms/page.tsx
@@ -14,7 +14,7 @@ export const metadata = {
     images: ["/Bittery-Logo.png"],
   },
 };
-import Link from "next/link";
+import { Link } from "../../../navigation";
 import { useTranslations } from "next-intl";
 
 export default function TermsPage() {
@@ -46,7 +46,7 @@ export default function TermsPage() {
 
       <p className="mt-8 text-sm text-gray-500">{t("lastUpdated", { date: "July 10, 2025" })}</p>
       <Link
-        href="../"
+        href="/"
         className="text-blue-600 hover:underline mt-4 inline-block title"
       >
         {t("backToHome")}

--- a/app/components/HomeClient.tsx
+++ b/app/components/HomeClient.tsx
@@ -5,7 +5,7 @@ import lotteryAbi from "../../contracts/Bittery.json";
 import InfoCarousel from "./InfoCarousel";
 import ReferralLink from "./ReferralLink";
 import EarningsTable from "./EarningsTable";
-import Link from "next/link";
+import { Link } from "../../navigation";
 import { useTranslations, useLocale } from "next-intl";
 
 const CONTRACT_ADDRESS = process.env.NEXT_PUBLIC_CONTRACT_ADDRESS || "";
@@ -154,13 +154,13 @@ export default function HomeClient() {
           {t("title")}
         </h1>
         <Link
-          href={`/${locale}/terms`}
+          href="/terms"
           className="text-sm text-gray-500 hover:underline"
         >
           {t("terms")} •
         </Link>{" "}
         <Link
-          href={`/${locale}/privacy`}
+          href="/privacy"
           className="text-sm text-gray-500 hover:underline"
         >
           {t("privacyPolicy")} •

--- a/app/components/TermsBanner.tsx
+++ b/app/components/TermsBanner.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useTranslations, useLocale } from "next-intl";
-import Link from "next/link";
+import { Link } from "../../navigation";
 
 const TERMS_VERSION = "2025-07-10"; // Atualize esta versão quando mudar os termos
 
@@ -29,14 +29,14 @@ export default function TermsBanner() {
         <p className="text-sm">
           {t("agreeTerms")} {" "}
           <Link
-            href={`/${locale}/terms`}
+            href="/terms"
             className="underline text-blue-400 hover:text-blue-300 title"
           >
             {t("terms")}
           </Link>{" "}
           {t("and") ?? "and"} {" "}
           <Link
-            href={`/${locale}/privacy`}
+            href="/privacy"
             className="underline text-blue-400 hover:text-blue-300 title"
           >
             {t("privacyPolicy")}


### PR DESCRIPTION
## Summary
- use `next-intl` navigation Link for locale-aware routing

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_6870de9028d0832f83e19c01a020687f