### PR TITLE
Fix contract address by network

### DIFF
--- a/app/components/AdminPanel.tsx
+++ b/app/components/AdminPanel.tsx
@@ -2,9 +2,9 @@
 import { useEffect, useState } from "react";
 import { ethers } from "ethers";
 import { useTranslations } from "next-intl";
+import { usePathname } from "../../navigation";
 import contractAbi from "../../contracts/Bittery.json"; // Replace with your ABI if needed
 
-const CONTRACT_ADDRESS = process.env.NEXT_PUBLIC_CONTRACT_ADDRESS || ""; // Replace with your deployed address
 
 interface Props {
   provider?: ethers.BrowserProvider;
@@ -13,6 +13,7 @@ interface Props {
 
 export default function AdminPanel({ provider, signer }: Props) {
   const t = useTranslations("common");
+  const pathname = usePathname();
   const [contract, setContract] = useState<ethers.Contract>();
   const [isOwner, setIsOwner] = useState(false);
   const [showPanel, setShowPanel] = useState(false);
@@ -25,13 +26,16 @@ export default function AdminPanel({ provider, signer }: Props) {
 
   useEffect(() => {
     if (!provider) return;
+    const address = pathname.includes('/main')
+      ? process.env.NEXT_PUBLIC_CONTRACT_ADDRESS_MAIN
+      : process.env.NEXT_PUBLIC_CONTRACT_ADDRESS_TEST;
     const c = new ethers.Contract(
-      CONTRACT_ADDRESS,
+      address ?? '',
       (contractAbi as any).abi || contractAbi,
       provider
     );
     setContract(c);
-  }, [provider]);
+  }, [provider, pathname]);
 
   useEffect(() => {
     if (!contract || !signer) return;

--- a/app/components/HomeClient.tsx
+++ b/app/components/HomeClient.tsx
@@ -5,14 +5,14 @@ import lotteryAbi from "../../contracts/Bittery.json";
 import InfoCarousel from "./InfoCarousel";
 import ReferralLink from "./ReferralLink";
 import EarningsTable from "./EarningsTable";
-import { Link } from "../../navigation";
+import { Link, usePathname } from "../../navigation";
 import { useTranslations, useLocale } from "next-intl";
 
-const CONTRACT_ADDRESS = process.env.NEXT_PUBLIC_CONTRACT_ADDRESS || "";
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const LAUNCH_DATE = new Date("2025-08-05T20:00:00-03:00").getTime();
 
 export default function HomeClient() {
+  const pathname = usePathname();
   const [provider, setProvider] = useState<ethers.BrowserProvider>();
   const [signer, setSigner] = useState<ethers.JsonRpcSigner>();
   const [players, setPlayers] = useState<string[]>([]);
@@ -79,7 +79,10 @@ export default function HomeClient() {
 
   useEffect(() => {
     if (!provider) return;
-    const c = new ethers.Contract(CONTRACT_ADDRESS, lotteryAbi.abi, provider);
+    const address = pathname.includes('/main')
+      ? process.env.NEXT_PUBLIC_CONTRACT_ADDRESS_MAIN
+      : process.env.NEXT_PUBLIC_CONTRACT_ADDRESS_TEST;
+    const c = new ethers.Contract(address ?? '', lotteryAbi.abi, provider);
     setContract(c);
     getPlayers(c);
     getWinner(c);
@@ -89,7 +92,7 @@ export default function HomeClient() {
       getWinners(c);
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [provider]);
+  }, [provider, pathname]);
 
   async function connect() {
     if ((window as any).ethereum) {


### PR DESCRIPTION
## Summary
- choose contract address based on `/test` or `/main` page
- use path inspection to load the proper network

## Testing
- `npm run lint` *(fails: interactive)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870e19acd40832f805db3a1245b7f32