### PR TITLE
Fix missing RPC errors

### DIFF
--- a/hooks/useBitteryContract.ts
+++ b/hooks/useBitteryContract.ts
@@ -15,6 +15,11 @@ export function useBitteryContract(network: Network) {
       return new ethers.Contract(address, abi, provider);
     }
     const rpc = publicClient?.transport?.url;
+    if (!rpc) {
+      throw new Error(
+        `RPC URL not configured for network ${network}. Check your wagmi setup.`
+      );
+    }
     const provider = new ethers.JsonRpcProvider(rpc);
     return new ethers.Contract(address, abi, provider);
   }, [walletClient, publicClient, network]);


### PR DESCRIPTION
## Summary
- check for missing RPC URL in `useBitteryContract`
- show descriptive error instead of failing fetch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6870f2060cb8832fa6503d801eea880c