### PR TITLE
Fix walletconnect storage in server build

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,16 @@ import type {NextConfig} from 'next';
 
 const withNextIntl = createNextIntlPlugin('./i18n.ts');
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  webpack: (config, { isServer }) => {
+    if (isServer) {
+      // Use the Node.js build of @walletconnect/keyvaluestorage on the server
+      config.resolve.alias["@walletconnect/keyvaluestorage"] = require.resolve(
+        "@walletconnect/keyvaluestorage/dist/index.cjs.js"
+      );
+    }
+    return config;
+  },
+};
 
 export default withNextIntl(nextConfig);


### PR DESCRIPTION
## Summary
- alias `@walletconnect/keyvaluestorage` to the Node build when running on the server

## Testing
- `npm run build` *(fails due to missing contract address but no longer shows `indexedDB` errors)*

------
https://chatgpt.com/codex/tasks/task_e_6870f8268c64832f8092b260c04f1ed4