### PR TITLE
Fix wallet event listener leak

### DIFF
--- a/app/components/ConnectWalletButton.tsx
+++ b/app/components/ConnectWalletButton.tsx
@@ -14,7 +14,11 @@ export default function ConnectWalletButton({ onConnect }: Props) {
       return;
     }
     try {
-      const provider = new ethers.BrowserProvider((window as any).ethereum);
+      const ethereum = (window as any).ethereum;
+      if (typeof ethereum.setMaxListeners === "function") {
+        ethereum.setMaxListeners(100);
+      }
+      const provider = new ethers.BrowserProvider(ethereum);
       await provider.send("eth_requestAccounts", []);
       const signer = await provider.getSigner();
       onConnect(provider, signer);

--- a/app/components/HomeClient.tsx
+++ b/app/components/HomeClient.tsx
@@ -87,10 +87,14 @@ export default function HomeClient() {
     getPlayers(c);
     getWinner(c);
     getWinners(c);
-    c.on("WinnerPicked", () => {
+    const listener = () => {
       getWinner(c);
       getWinners(c);
-    });
+    };
+    c.on("WinnerPicked", listener);
+    return () => {
+      c.off("WinnerPicked", listener);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [provider, pathname]);
 


### PR DESCRIPTION
## Summary
- avoid accumulating WinnerPicked listeners by cleaning up on effect teardown
- raise MetaMask listener limit to prevent warnings

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68710fe544e4832f8e49d2348afd52aa