### PR TITLE
Fix repeated WalletConnect init

### DIFF
--- a/app/components/WagmiProviders.tsx
+++ b/app/components/WagmiProviders.tsx
@@ -2,20 +2,24 @@
 import { WagmiConfig, http } from "wagmi";
 import { polygon, sepolia } from "wagmi/chains";
 import { RainbowKitProvider, getDefaultConfig } from "@rainbow-me/rainbowkit";
-import { ReactNode, useState } from "react";
+import { ReactNode, useMemo, useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 export default function WagmiProviders({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
-  const wagmiConfig = getDefaultConfig({
-    appName: "Bittery",
-    projectId: "bittery",
-    chains: [polygon, sepolia] as const,
-    transports: {
-      [polygon.id]: http(),
-      [sepolia.id]: http(),
-    },
-  });
+  const wagmiConfig = useMemo(
+    () =>
+      getDefaultConfig({
+        appName: "Bittery",
+        projectId: "bittery",
+        chains: [polygon, sepolia] as const,
+        transports: {
+          [polygon.id]: http(),
+          [sepolia.id]: http(),
+        },
+      }),
+    []
+  );
   return (
     <QueryClientProvider client={queryClient}>
       <WagmiConfig config={wagmiConfig}>


### PR DESCRIPTION
## Summary
- avoid re-creating the WalletConnect config on every render

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68717cbb1004832fa3fe37a8cea259c8