### PR TITLE
Adjust prize calculation in RoomCard

### DIFF
--- a/app/components/RoomCard.tsx
+++ b/app/components/RoomCard.tsx
@@ -33,7 +33,7 @@ export default function RoomCard({ network, id }: Props) {
     setMaxPlayers(Number(room.maxPlayers));
     const p = Number(ethers.formatEther(room.ticketPrice));
     setPrice(p);
-    setPrize(p * room.maxPlayers);
+    setPrize(p * Number(room.maxPlayers) * 0.95);
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- show final prize minus 5% fee per ticket in RoomCard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68717e03ca54832fbc2b4cee0647e545