### PR TITLE
Group rooms by player count

### DIFF
--- a/app/components/RoomsView.tsx
+++ b/app/components/RoomsView.tsx
@@ -6,13 +6,22 @@ import RoomCard from './RoomCard';
 
 export default function RoomsView({ network }: { network: Network }) {
   const contract = useBitteryContract(network);
-  const [ids, setIds] = useState<number[]>([]);
+  const [groups, setGroups] = useState<Record<number, number[]>>({});
 
   useEffect(() => {
     async function load() {
       try {
         const next = Number(await contract.nextRoomId());
-        setIds(Array.from({ length: next }, (_, i) => i));
+        const rooms = await Promise.all(
+          Array.from({ length: next }, (_, i) => contract.rooms(i))
+        );
+        const mapping: Record<number, number[]> = {};
+        rooms.forEach((room: any) => {
+          const max = Number(room.maxPlayers);
+          if (!mapping[max]) mapping[max] = [];
+          mapping[max].push(Number(room.id));
+        });
+        setGroups(mapping);
       } catch (err) {
         console.error(err);
       }
@@ -20,10 +29,21 @@ export default function RoomsView({ network }: { network: Network }) {
     load();
   }, [contract]);
 
+  const sorted = Object.entries(groups).sort(
+    ([a], [b]) => Number(a) - Number(b)
+  );
+
   return (
-    <div className="grid md:grid-cols-2 gap-4">
-      {ids.map((id) => (
-        <RoomCard key={id} network={network} id={id} />
+    <div className="space-y-8">
+      {sorted.map(([max, ids]) => (
+        <div key={max} className="space-y-2">
+          <h2 className="text-xl font-bold">{max} Player Rooms</h2>
+          <div className="grid md:grid-cols-2 gap-4">
+            {ids.map((id) => (
+              <RoomCard key={id} network={network} id={id} />
+            ))}
+          </div>
+        </div>
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- organize `RoomsView` to group room cards by `maxPlayers`

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68717f9ada30832f918bcff93db69920