### PR TITLE
Fix WalletConnect docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,14 @@ NEXT_PUBLIC_CONTRACT_ADDRESS_MAIN=0xYourMainnetAddress
 NEXT_PUBLIC_CHAIN_ID_MAIN=137
 NEXT_PUBLIC_CONTRACT_ADDRESS_TEST=0xYourTestnetAddress
 NEXT_PUBLIC_CHAIN_ID_TEST=11155111
+# WalletConnect project identifier for RainbowKit
+NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=your_walletconnect_id
 ```
+
+The WalletConnect project ID identifies your app on WalletConnect Cloud. Sign up
+at <https://cloud.walletconnect.com>, create a project, and copy the generated
+identifier. If not provided, the app falls back to the default `bittery`
+identifier used in development.
 
 If these variables are missing the app will attempt to create a contract with an empty address and throw an `UNCONFIGURED_NAME` error.
 

--- a/app/components/WagmiProviders.tsx
+++ b/app/components/WagmiProviders.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { WagmiConfig, http } from "wagmi";
+import { WagmiProvider, http } from "wagmi";
 import { polygon, sepolia } from "wagmi/chains";
 import { RainbowKitProvider, getDefaultConfig } from "@rainbow-me/rainbowkit";
 import { ReactNode, useMemo, useState } from "react";
@@ -11,7 +11,8 @@ export default function WagmiProviders({ children }: { children: ReactNode }) {
     () =>
       getDefaultConfig({
         appName: "Bittery",
-        projectId: "bittery",
+        projectId:
+          process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || "bittery",
         chains: [polygon, sepolia] as const,
         transports: {
           [polygon.id]: http(),
@@ -22,9 +23,9 @@ export default function WagmiProviders({ children }: { children: ReactNode }) {
   );
   return (
     <QueryClientProvider client={queryClient}>
-      <WagmiConfig config={wagmiConfig}>
+      <WagmiProvider config={wagmiConfig}>
         <RainbowKitProvider>{children}</RainbowKitProvider>
-      </WagmiConfig>
+      </WagmiProvider>
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## Summary
- clarify how to obtain a WalletConnect project identifier
- switch deprecated `WagmiConfig` to the new `WagmiProvider`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `hardhat` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687180ab5320832f9a95bba19632dfda