### PR TITLE
Fix verify scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "test": "hardhat test",
     "deploy:test": "npx hardhat clean && hardhat run scripts/deploy.ts --network sepolia",
     "deploy:main": "npx hardhat clean && hardhat run scripts/deploy.ts --network polygon",
-    "verify:test": "hardhat verify --network sepolia <CONTRACT_ADDRESS> <constructor args...>",
-    "verify:main": "hardhat verify --network polygon <CONTRACT_ADDRESS> <constructor args...>",
+    "verify:test": "npx hardhat verify --network sepolia <CONTRACT_ADDRESS> <constructor args...>",
+    "verify:main": "npx hardhat verify --network polygon <CONTRACT_ADDRESS> <constructor args...>",
     "schedule": "ts-node scripts/scheduleDraw.ts",
     "schedule:rooms": "ts-node scripts/scheduleRooms.ts",
     "init:rooms": "ts-node scripts/initRooms.ts"


### PR DESCRIPTION
## Summary
- switch `verify:test` and `verify:main` scripts to invoke Hardhat via `npx`

## Testing
- `npm test` *(fails: hardhat not found)*
- `npm install --silent` *(no output, likely due to network or config issues)*

------
https://chatgpt.com/codex/tasks/task_e_687198708e94832faa48f8287d05171d