### PR TITLE
Fix native symbol selection by network

### DIFF
--- a/hooks/useNativeSymbol.ts
+++ b/hooks/useNativeSymbol.ts
@@ -1,12 +1,17 @@
 "use client";
 import { useEffect, useState } from "react";
-import { getContractConfig, Network } from "../lib/contracts";
+import { Network } from "../lib/contracts";
 import { getNativeSymbol } from "../lib/native";
 
 export function useNativeSymbol(network?: Network) {
   const [symbol, setSymbol] = useState("ETH");
 
   useEffect(() => {
+    if (network) {
+      setSymbol(network === "main" ? "MATIC" : "ETH");
+      return;
+    }
+
     let active = true;
     function updateFromChain(chainIdHex: string) {
       const id = parseInt(chainIdHex, 16);
@@ -18,9 +23,7 @@ export function useNativeSymbol(network?: Network) {
     if (ethereum?.chainId) {
       updateFromChain(ethereum.chainId as string);
     } else {
-      const envId = network
-        ? getContractConfig(network).chainId
-        : Number(process.env.NEXT_PUBLIC_CHAIN_ID_MAIN || "137");
+      const envId = Number(process.env.NEXT_PUBLIC_CHAIN_ID_MAIN || "137");
       setSymbol(getNativeSymbol(envId));
     }
     if (ethereum?.on) {


### PR DESCRIPTION
## Summary
- refactor `useNativeSymbol` hook to pick the correct symbol for the provided network

## Testing
- `npx hardhat test` *(fails: needs hardhat package)*

------
https://chatgpt.com/codex/tasks/task_e_6871a9d134b0832f8ecba4f584612294