### PR TITLE
Implement dynamic MATIC pricing

### DIFF
--- a/app/api/schedule-rooms/route.ts
+++ b/app/api/schedule-rooms/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from 'next/server';
 import { ethers } from 'ethers';
 import artifact from '../../../contracts/Bittery.json';
+import { Network } from '../../../lib/contracts';
+import { getRooms, RoomConfig } from '../../../lib/rooms';
 
 export const runtime = 'nodejs';
 
 const PRIVATE_KEY = process.env.PRIVATE_KEY || '';
-
-type Network = 'test' | 'main';
 
 function getNetworkConfig(network: Network) {
   const rpcUrl =
@@ -29,30 +29,12 @@ function getNetworkConfig(network: Network) {
   return { contract };
 }
 
-interface RoomConfig {
-  maxPlayers: number;
-  price: string; // in ETH
-}
 
-const rooms: RoomConfig[] = [
-  { maxPlayers: 10, price: '0.01' },
-  { maxPlayers: 10, price: '0.001' },
-  { maxPlayers: 10, price: '0.0005' },
-  { maxPlayers: 20, price: '0.01' },
-  { maxPlayers: 20, price: '0.001' },
-  { maxPlayers: 20, price: '0.0005' },
-  { maxPlayers: 50, price: '0.01' },
-  { maxPlayers: 50, price: '0.001' },
-  { maxPlayers: 50, price: '0.0005' },
-  { maxPlayers: 100, price: '0.01' },
-  { maxPlayers: 100, price: '0.001' },
-  { maxPlayers: 100, price: '0.0005' },
-  { maxPlayers: 1000, price: '0.01' },
-  { maxPlayers: 1000, price: '0.001' },
-  { maxPlayers: 1000, price: '0.0005' },
-];
-
-async function ensureRoomsForContract(contract: ethers.Contract) {
+async function ensureRoomsForContract(
+  contract: ethers.Contract,
+  rooms: RoomConfig[],
+  network: Network
+) {
   const next = await contract.nextRoomId();
   const total = Number(next);
 
@@ -77,8 +59,9 @@ async function ensureRoomsForContract(contract: ethers.Contract) {
             maxPlayers
           );
           await tx.wait();
+          const symbol = network === 'main' ? 'MATIC' : 'ETH';
           console.log(
-            `Created room #${(await contract.nextRoomId()) - 1n} with price ${price} ETH and ${maxPlayers} players`
+            `Created room #${(await contract.nextRoomId()) - 1n} with price ${price} ${symbol} and ${maxPlayers} players`
           );
         }
         break;
@@ -91,14 +74,16 @@ async function ensureRoomsForContract(contract: ethers.Contract) {
         maxPlayers
       );
       await tx.wait();
-      console.log(`Created initial room with price ${price} ETH and ${maxPlayers} players`);
+      const symbol = network === 'main' ? 'MATIC' : 'ETH';
+      console.log(`Created initial room with price ${price} ${symbol} and ${maxPlayers} players`);
     }
   }
 }
 
 async function ensureRooms(network: Network) {
   const { contract } = getNetworkConfig(network);
-  await ensureRoomsForContract(contract);
+  const rooms = await getRooms(network);
+  await ensureRoomsForContract(contract, rooms, network);
 }
 
 export async function GET(req: Request) {

--- a/lib/rooms.ts
+++ b/lib/rooms.ts
@@ -1,0 +1,51 @@
+import { Network } from './contracts';
+
+export interface RoomConfig {
+  maxPlayers: number;
+  price: string; // in native token
+}
+
+const BASE_ROOMS: RoomConfig[] = [
+  { maxPlayers: 10, price: '0.01' },
+  { maxPlayers: 10, price: '0.001' },
+  { maxPlayers: 10, price: '0.0005' },
+  { maxPlayers: 20, price: '0.01' },
+  { maxPlayers: 20, price: '0.001' },
+  { maxPlayers: 20, price: '0.0005' },
+  { maxPlayers: 50, price: '0.01' },
+  { maxPlayers: 50, price: '0.001' },
+  { maxPlayers: 50, price: '0.0005' },
+  { maxPlayers: 100, price: '0.01' },
+  { maxPlayers: 100, price: '0.001' },
+  { maxPlayers: 100, price: '0.0005' },
+  { maxPlayers: 1000, price: '0.01' },
+  { maxPlayers: 1000, price: '0.001' },
+  { maxPlayers: 1000, price: '0.0005' },
+];
+
+const PRICE_API =
+  'https://min-api.cryptocompare.com/data/pricemulti?fsyms=ETH,MATIC&tsyms=USD';
+
+async function fetchPrices() {
+  const res = await fetch(PRICE_API);
+  if (!res.ok) {
+    throw new Error('failed to fetch prices');
+  }
+  const data = await res.json();
+  const eth = data?.ETH?.USD;
+  const matic = data?.MATIC?.USD;
+  if (!eth || !matic) {
+    throw new Error('invalid price data');
+  }
+  return { eth, matic };
+}
+
+export async function getRooms(network: Network): Promise<RoomConfig[]> {
+  if (network === 'test') return BASE_ROOMS;
+  const { eth, matic } = await fetchPrices();
+  const factor = eth / matic;
+  return BASE_ROOMS.map((room) => ({
+    maxPlayers: room.maxPlayers,
+    price: (parseFloat(room.price) * factor).toFixed(6),
+  }));
+}


### PR DESCRIPTION
## Summary
- add shared `getRooms` helper
- calculate MATIC prices on mainnet using current ETH/MATIC rate
- update init and scheduler scripts to use dynamic room configs
- adjust API route to create rooms with MATIC price on mainnet

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871ab9b120c832f9cc9e78be394098b