### PR TITLE
Remove unused locale constant

### DIFF
--- a/app/components/TermsBanner.tsx
+++ b/app/components/TermsBanner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useTranslations, useLocale } from "next-intl";
+import { useTranslations } from "next-intl";
 import { Link } from "../../navigation";
 
 const TERMS_VERSION = "2025-07-10"; // Atualize esta versão quando mudar os termos
@@ -9,7 +9,6 @@ const TERMS_VERSION = "2025-07-10"; // Atualize esta versão quando mudar os ter
 export default function TermsBanner() {
   const [accepted, setAccepted] = useState<boolean>(true);
   const t = useTranslations("common");
-  const locale = useLocale();
 
   useEffect(() => {
     const savedVersion = localStorage.getItem("termsVersionAccepted");


### PR DESCRIPTION
## Summary
- drop unused `locale` variable from `TermsBanner`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'hardhat/config', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6871b9c3702c832faec7d29b317a262a