### PR TITLE
Update fallback chain ID logic

### DIFF
--- a/hooks/useNativeSymbol.ts
+++ b/hooks/useNativeSymbol.ts
@@ -23,7 +23,11 @@ export function useNativeSymbol(network?: Network) {
     if (ethereum?.chainId) {
       updateFromChain(ethereum.chainId as string);
     } else {
-      const envId = Number(process.env.NEXT_PUBLIC_CHAIN_ID_MAIN || "137");
+      const envId = Number(
+        process.env.NEXT_PUBLIC_CHAIN_ID_MAIN ||
+          process.env.NEXT_PUBLIC_CHAIN_ID_TEST ||
+          "137"
+      );
       setSymbol(getNativeSymbol(envId));
     }
     if (ethereum?.on) {


### PR DESCRIPTION
## Summary
- support using both `NEXT_PUBLIC_CHAIN_ID_MAIN` and `NEXT_PUBLIC_CHAIN_ID_TEST` when no wallet is connected

## Testing
- `npm test`
- `npm run lint`
- `npx ts-node -O '{"types":["node"],"module":"commonjs"}' -e "const native=require('./lib/native'); console.log(native.getNativeSymbol(Number(process.env.NEXT_PUBLIC_CHAIN_ID_MAIN||process.env.NEXT_PUBLIC_CHAIN_ID_TEST||'137')));"`
- `NEXT_PUBLIC_CHAIN_ID_TEST=11155111 npx ts-node -O '{"types":["node"],"module":"commonjs"}' -e "const native=require('./lib/native'); console.log(native.getNativeSymbol(Number(process.env.NEXT_PUBLIC_CHAIN_ID_MAIN||process.env.NEXT_PUBLIC_CHAIN_ID_TEST||'137')));"`

------
https://chatgpt.com/codex/tasks/task_e_6871b9ae7980832f88c83a49f27d201d