### PR TITLE
Clarify RPC config for Hardhat

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ CRON_SECRET=your_secret_for_cron
 Variables ending in `_MAIN` apply to Polygon mainnet, while `_TEST` ones are
 for Ethereum Sepolia.
 
+If `POLYGON_RPC_URL` or `SEPOLIA_RPC_URL` are missing Hardhat will fail with
+```
+ProviderError: the method eth_blockNumber does not exist/is not available
+```
+Ensure both RPC endpoints and `PRIVATE_KEY` are correctly configured.
+
 Then deploy with:
 ```bash
 npx hardhat run scripts/deploy.ts --network sepolia

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -6,6 +6,19 @@ dotenv.config();
 async function main() {
   const networkName = network.name;
 
+  const rpcUrl =
+    networkName === "sepolia"
+      ? process.env.SEPOLIA_RPC_URL
+      : process.env.POLYGON_RPC_URL;
+  const privateKey = process.env.PRIVATE_KEY;
+
+  if (!rpcUrl || !privateKey) {
+    console.error(
+      "❌ Erro: RPC_URL e PRIVATE_KEY devem estar definidos nas variáveis de ambiente."
+    );
+    process.exit(1);
+  }
+
   let coordinatorRaw: string | undefined;
   let subscriptionIdRaw: string | undefined;
   let keyHashRaw: string | undefined;


### PR DESCRIPTION
## Summary
- verify RPC_URL and PRIVATE_KEY in the deploy script
- document Hardhat error when RPC env vars are missing

## Testing
- `npm install`
- `POLYGON_RPC_URL=https://polygon-rpc.com SEPOLIA_RPC_URL=https://rpc.sepolia.org PRIVATE_KEY=0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef npm test`


------
https://chatgpt.com/codex/tasks/task_e_6871c0e24ba0832f884f3eb36d6df060