### PR TITLE
Refactor scheduleDraw for dual networks

### DIFF
--- a/scripts/scheduleDraw.ts
+++ b/scripts/scheduleDraw.ts
@@ -1,50 +1,60 @@
 import { ethers } from "ethers";
 import cron from "node-cron";
 import * as dotenv from "dotenv";
-import lotteryAbi from "../contracts/Bittery.json";
+import artifact from "../contracts/Bittery.json";
+import { Network } from "../lib/contracts";
 
 dotenv.config();
 
-const RPC_URL =
-  process.env.POLYGON_RPC_URL || process.env.SEPOLIA_RPC_URL || "";
 const PRIVATE_KEY = process.env.PRIVATE_KEY || "";
-const CONTRACT_ADDRESS =
-  process.env.NEXT_PUBLIC_CONTRACT_ADDRESS_MAIN ||
-  process.env.NEXT_PUBLIC_CONTRACT_ADDRESS_TEST ||
-  "";
 
-if (!RPC_URL || !PRIVATE_KEY) {
-  console.error("RPC_URL and PRIVATE_KEY must be set in the environment");
-  process.exit(1);
+function getNetworkConfig(network: Network) {
+  const rpcUrl =
+    network === "main" ? process.env.POLYGON_RPC_URL : process.env.SEPOLIA_RPC_URL;
+  const contractAddress =
+    network === "main"
+      ? process.env.NEXT_PUBLIC_CONTRACT_ADDRESS_MAIN
+      : process.env.NEXT_PUBLIC_CONTRACT_ADDRESS_TEST;
+
+  if (!rpcUrl || !contractAddress || !PRIVATE_KEY) {
+    throw new Error(`Missing env vars for ${network}`);
+  }
+
+  const provider = new ethers.JsonRpcProvider(rpcUrl);
+  const wallet = new ethers.Wallet(PRIVATE_KEY, provider);
+  const contract = new ethers.Contract(
+    contractAddress,
+    (artifact as any).abi || artifact,
+    wallet
+  );
+
+  return { contract };
 }
 
-const provider = new ethers.JsonRpcProvider(RPC_URL);
-const wallet = new ethers.Wallet(PRIVATE_KEY, provider);
-const lottery = new ethers.Contract(CONTRACT_ADDRESS, lotteryAbi.abi, wallet);
-
-async function draw() {
+async function drawForContract(contract: ethers.Contract, network: Network) {
   try {
-    const total = Number(await lottery.nextRoomId());
+    const total = Number(await contract.nextRoomId());
     for (let i = 0; i < total; i++) {
-      const players: string[] = await lottery.getRoomPlayers(i);
-      const room = await lottery.rooms(i);
+      const players: string[] = await contract.getRoomPlayers(i);
+      const room = await contract.rooms(i);
       if (
         !room.drawing &&
         room.winner === ethers.ZeroAddress &&
         players.length >= 2
       ) {
         const drawFn =
-          (lottery as any).draw ?? (lottery as any).requestRandomWinner;
+          (contract as any).draw ?? (contract as any).requestRandomWinner;
         if (typeof drawFn === "function") {
           const tx = await drawFn(i);
           await tx.wait();
-          console.log(`Winner request sent for room ${i}`, tx.hash);
+          const symbol = network === "main" ? "POL" : "ETH";
+          console.log(`Winner request sent for room ${i} on ${network} (${symbol})`, tx.hash);
         } else {
           console.log("No public draw function found on contract");
           break;
         }
       } else {
-        console.log(`Skipping room ${i}, only ${players.length} player(s)`);
+        console.log(`Skipping room ${i} on ${network}, only ${players.length} player(s)`);
       }
     }
   } catch (err) {
@@ -52,8 +62,15 @@ async function draw() {
   }
 }
 
+async function draw(network: Network) {
+  const { contract } = getNetworkConfig(network);
+  await drawForContract(contract, network);
+}
+
 // Run every Sunday at 20:00
 cron.schedule("0 20 * * 0", () => {
   console.log("Running scheduled lottery draw...");
-  draw();
+  Promise.all([draw("test"), draw("main")]).catch((err) =>
+    console.error("Failed to execute draws:", err)
+  );
 });


### PR DESCRIPTION
## Summary
- refactor scheduleDraw.ts to draw on mainnet and testnet

## Testing
- `npm test` *(fails: no matching fragment for createRoom)*

------
https://chatgpt.com/codex/tasks/task_e_6871eb60f634832fb2ba87d07774ba63