### PR TITLE
Handle BAD_DATA errors for empty contract calls

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -30,12 +30,13 @@ export default function Navbar() {
     async function load() {
       try {
         const val = await contract.payments(address);
-        if (val === "0x") {
-          setBalance("0");
-        }
         setBalance(ethers.formatEther(val));
-      } catch (err) {
-        console.error(err);
+      } catch (err: any) {
+        if (err.code === "BAD_DATA") {
+          setBalance("0");
+        } else {
+          console.error(err);
+        }
       }
     }
     load();
@@ -51,13 +52,14 @@ export default function Navbar() {
         .withdrawPayments(address);
       await tx.wait();
       const val = await contract.payments(address);
-      if (val === "0x") {
-        setBalance("0");
-      }
       setBalance(ethers.formatEther(val));
       setOpen(false);
-    } catch (err) {
-      console.error(err);
+    } catch (err: any) {
+      if (err.code === "BAD_DATA") {
+        setBalance("0");
+      } else {
+        console.error(err);
+      }
     }
   }
 

--- a/app/components/RoomsView.tsx
+++ b/app/components/RoomsView.tsx
@@ -11,7 +11,16 @@ export default function RoomsView({ network }: { network: Network }) {
   useEffect(() => {
     async function load() {
       try {
-        const next = Number(await contract.getNextRoomId());
+        let next = 0;
+        try {
+          next = Number(await contract.getNextRoomId());
+        } catch (err: any) {
+          if (err.code === "BAD_DATA") {
+            setGroups({});
+            return;
+          }
+          throw err;
+        }
         if (next === 0) {
           setGroups({});
           return;


### PR DESCRIPTION
## Summary
- handle BAD_DATA cases when calling `getNextRoomId`
- handle BAD_DATA cases when checking payment balance and withdrawing

## Testing
- `npm test` *(fails: Invalid value undefined for HardhatConfig.networks.polygon.url)*

------
https://chatgpt.com/codex/tasks/task_e_68726eea0408832fb1a2f0c90644beab