### PR TITLE
Handle zero return when reading nextRoomId

### DIFF
--- a/app/api/schedule-rooms/route.ts
+++ b/app/api/schedule-rooms/route.ts
@@ -35,7 +35,16 @@ async function ensureRoomsForContract(
   rooms: RoomConfig[],
   network: Network
 ) {
-  const next = await contract.nextRoomId();
+  let next: bigint;
+  try {
+    next = await contract.nextRoomId();
+  } catch (err: any) {
+    if (err?.message?.includes('bad data')) {
+      next = 0n;
+    } else {
+      throw err;
+    }
+  }
   const total = Number(next);
 
   for (const { price, maxPlayers } of rooms) {


### PR DESCRIPTION
## Summary
- handle `bad data` error when calling `contract.nextRoomId`

## Testing
- `npm test` *(fails: no matching fragment 'createRoom')*
- `npm run build` *(fails: Contract address not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68727571ec5c832fb023e606bc60536c