### PR TITLE
Fix WalletConnect init duplication

### DIFF
--- a/app/components/WagmiProviders.tsx
+++ b/app/components/WagmiProviders.tsx
@@ -2,25 +2,22 @@
 import { WagmiProvider, http } from "wagmi";
 import { polygon, sepolia } from "wagmi/chains";
 import { RainbowKitProvider, getDefaultConfig } from "@rainbow-me/rainbowkit";
-import { ReactNode, useMemo, useState } from "react";
+import { ReactNode, useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const wagmiConfig = getDefaultConfig({
+  appName: "Bittery",
+  projectId:
+    process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || "bittery",
+  chains: [polygon, sepolia] as const,
+  transports: {
+    [polygon.id]: http(process.env.NEXT_PUBLIC_POLYGON_RPC_URL || ""),
+    [sepolia.id]: http(process.env.NEXT_PUBLIC_SEPOLIA_RPC_URL || ""),
+  },
+});
 
 export default function WagmiProviders({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
-  const wagmiConfig = useMemo(
-    () =>
-      getDefaultConfig({
-        appName: "Bittery",
-        projectId:
-          process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || "bittery",
-        chains: [polygon, sepolia] as const,
-        transports: {
-          [polygon.id]: http(process.env.NEXT_PUBLIC_POLYGON_RPC_URL || ""),
-          [sepolia.id]: http(process.env.NEXT_PUBLIC_SEPOLIA_RPC_URL || ""),
-        },
-      }),
-    []
-  );
   return (
     <QueryClientProvider client={queryClient}>
       <WagmiProvider config={wagmiConfig}>


### PR DESCRIPTION
## Summary
- prevent repeated WalletConnect initialization by creating wagmi config once

## Testing
- `npm test` *(fails: hardhat not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68728093899c832f97a3842521a7046b