### PR TITLE
Add history view and change room creation rule

### DIFF
--- a/app/[locale]/main/history/page.tsx
+++ b/app/[locale]/main/history/page.tsx
@@ -1,0 +1,15 @@
+import HistoryView from "../../../components/HistoryView";
+import { useTranslations } from "next-intl";
+
+export const metadata = { title: "History" };
+
+export default function MainHistoryPage() {
+  const t = useTranslations("common");
+  return (
+    <main className="flex flex-col items-center gap-4 p-8">
+      <h1 className="text-2xl font-bold">{t("historyTitle")}</h1>
+      <p className="text-gray-600">{t("historyDescription")}</p>
+      <HistoryView network="main" />
+    </main>
+  );
+}

--- a/app/[locale]/test/history/page.tsx
+++ b/app/[locale]/test/history/page.tsx
@@ -1,0 +1,15 @@
+import HistoryView from "../../../components/HistoryView";
+import { useTranslations } from "next-intl";
+
+export const metadata = { title: "History" };
+
+export default function TestHistoryPage() {
+  const t = useTranslations("common");
+  return (
+    <main className="flex flex-col items-center gap-4 p-8">
+      <h1 className="text-2xl font-bold">{t("historyTitle")}</h1>
+      <p className="text-gray-600">{t("historyDescription")}</p>
+      <HistoryView network="test" />
+    </main>
+  );
+}

--- a/app/api/schedule-rooms/route.ts
+++ b/app/api/schedule-rooms/route.ts
@@ -62,8 +62,7 @@ async function ensureRoomsForContract(
         latestIndex = i;
         const roomPlayers: string[] = room.players;
         const finished =
-          room.winner !== ethers.ZeroAddress ||
-          room.drawing ||
+          room.winner !== ethers.ZeroAddress &&
           roomPlayers.length >= maxPlayers;
         if (finished) {
           const tx = await contract.createRoom(

--- a/app/components/HistoryView.tsx
+++ b/app/components/HistoryView.tsx
@@ -5,7 +5,7 @@ import { useBitteryContract } from "../../hooks/useBitteryContract";
 import { Network } from "../../lib/contracts";
 import RoomCard from "./RoomCard";
 
-export default function RoomsView({ network }: { network: Network }) {
+export default function HistoryView({ network }: { network: Network }) {
   const contract = useBitteryContract(network);
   const [groups, setGroups] = useState<Record<number, number[]>>({});
 
@@ -37,7 +37,7 @@ export default function RoomsView({ network }: { network: Network }) {
         }
         const mapping: Record<number, number[]> = {};
         rooms.forEach((room: any) => {
-          if (room.winner === ethers.ZeroAddress) {
+          if (room.winner !== ethers.ZeroAddress) {
             const max = Number(room.maxPlayers);
             if (!mapping[max]) mapping[max] = [];
             mapping[max].push(Number(room.id));

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState, useEffect } from "react";
 import { Link, usePathname } from "../../navigation";
+import { useTranslations } from "next-intl";
 import { useAccount } from "wagmi";
 import { useBitteryContract } from "../../hooks/useBitteryContract";
 import { Network } from "../../lib/contracts";
@@ -18,6 +19,7 @@ export default function Navbar() {
   const { address, isConnected } = useAccount();
   const contract = useBitteryContract(network);
   const symbol = useNativeSymbol(network);
+  const t = useTranslations("common");
   const [balance, setBalance] = useState<string>("0");
   const [open, setOpen] = useState(false);
 
@@ -75,9 +77,17 @@ export default function Navbar() {
 
   return (
     <nav className="bg-neutral-900 text-white flex justify-between  items-center px-4 py-2 gap-4">
-      <Link href="/" className="flex items-center gap-2">
-        <img src="/nav3.png" alt="Logo" width={40} height={40} />
-      </Link>
+      <div className="flex items-center gap-4">
+        <Link href="/" className="flex items-center gap-2">
+          <img src="/nav3.png" alt="Logo" width={40} height={40} />
+        </Link>
+        <Link
+          href={`/${network}/history`}
+          className="text-sm hover:underline hidden sm:inline-block"
+        >
+          {t("historyLink")}
+        </Link>
+      </div>
 
       <div className="relative">
         {isConnected && address ? (

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -77,6 +77,9 @@
     "privacyBullet5": "Wir können anonyme Analysen verwenden, um die Leistung der Website zu verbessern.",
     "privacyConclusion": "Durch die Verwendung von Bitterie stimmen Sie dieser Datenschutzrichtlinie zu. Wenn Sie nicht zustimmen, trennen Sie die Anwendung bitte die Verbindung und unterlassen Sie sie nicht.",
     "lastUpdated": "Zuletzt aktualisiert: {date}",
+    "historyLink": "History",
+    "historyTitle": "Completed Rooms",
+    "historyDescription": "Rooms that already have a winner.",
     "locale": "de"
   }
 }

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -78,6 +78,9 @@
     "privacyBullet5": "We may use anonymous analytics to improve site performance.",
     "privacyConclusion": "By using Bittery, you consent to this privacy policy. If you do not agree, please disconnect and refrain from using the application.",
     "lastUpdated": "Last updated: {date}",
+    "historyLink": "History",
+    "historyTitle": "Completed Rooms",
+    "historyDescription": "Rooms that already have a winner.",
     "locale": "en"
   }
 }

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -77,6 +77,9 @@
     "privacyBullet5": "Podemos usar análisis anónimos para mejorar el rendimiento del sitio.",
     "privacyConclusion": "Al usar Bittery, usted acepta esta Política de privacidad. Si no está de acuerdo, desconecte y abstenga de usar la aplicación.",
     "lastUpdated": "Última actualización: {date}",
+    "historyLink": "History",
+    "historyTitle": "Completed Rooms",
+    "historyDescription": "Rooms that already have a winner.",
     "locale": "es"
   }
 }

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -77,6 +77,9 @@
     "privacyBullet5": "Nous pouvons utiliser des analyses anonymes pour améliorer les performances du site.",
     "privacyConclusion": "En utilisant Bitter, vous consentez à cette politique de confidentialité. Si vous n'êtes pas d'accord, veuillez déconnecter et vous abstenir d'utiliser l'application.",
     "lastUpdated": "Dernière mise à jour: {date}",
+    "historyLink": "History",
+    "historyTitle": "Completed Rooms",
+    "historyDescription": "Rooms that already have a winner.",
     "locale": "fr"
   }
 }

--- a/locales/pt/common.json
+++ b/locales/pt/common.json
@@ -78,6 +78,9 @@
     "privacyBullet5": "Podemos usar análises anônimas para melhorar a performance do site.",
     "privacyConclusion": "Ao usar a Bittery, você concorda com esta política de privacidade. Se não concorda, desconecte-se e pare de usar a aplicação.",
     "lastUpdated": "Última atualização: {date}",
+    "historyLink": "Histórico",
+    "historyTitle": "Salas Finalizadas",
+    "historyDescription": "Histórico de salas que já possuem vencedor.",
     "locale": "pt"
 
   }

--- a/locales/ru/common.json
+++ b/locales/ru/common.json
@@ -77,6 +77,9 @@
     "privacyBullet5": "Мы можем использовать анонимную аналитику для повышения производительности сайта.",
     "privacyConclusion": "Используя Bittery, вы соглашаетесь с этой политикой конфиденциальности. Если вы не согласны, пожалуйста, отключите и воздержитесь от использования приложения.",
     "lastUpdated": "Последнее обновление: {date}",
+    "historyLink": "History",
+    "historyTitle": "Completed Rooms",
+    "historyDescription": "Rooms that already have a winner.",
     "locale": "ru"
   }
 }

--- a/locales/sv/common.json
+++ b/locales/sv/common.json
@@ -77,6 +77,9 @@
     "privacyBullet5": "Vi kan använda anonyma analyser för att förbättra webbplatsens prestanda.",
     "privacyConclusion": "Genom att använda Bittery samtycker du till denna sekretesspolicy. Om du inte håller med, vänligen koppla bort och avstå från att använda applikationen.",
     "lastUpdated": "Senast uppdaterad: {date}",
+    "historyLink": "History",
+    "historyTitle": "Completed Rooms",
+    "historyDescription": "Rooms that already have a winner.",
     "locale": "sv"
   }
 }


### PR DESCRIPTION
## Summary
- only create a new room when the previous one is full **and** already has a winner
- hide completed rooms from the main view
- add history view for finished rooms
- link to history in the navbar
- provide translation strings for the new page

## Testing
- `npm test` *(fails: non-owner revert reason mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68728359c6e4832fa4682a5ae5d6a8f1