### PR TITLE
Apply launch check for mainnet link

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -3,7 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import TermsBanner from "../components/TermsBanner";
 import Footer from "../components/Footer";
 import Navbar from "../components/Navbar";
-import Networks from "../components/Networks";
+import NetworksClient from "../components/NetworksClient";
 import "../globals.css";
 import "@rainbow-me/rainbowkit/styles.css";
 import WagmiProviders from "../components/WagmiProviders";
@@ -67,7 +67,7 @@ export default async function RootLayout({ children, params }: any) {
         <WagmiProviders>
           <NextIntlClientProvider locale={locale} messages={messages}>
             <Navbar />
-            <Networks />
+            <NetworksClient />
             <main className="flex-grow">{children}</main>
             <Footer />
             <TermsBanner />

--- a/app/components/Networks.tsx
+++ b/app/components/Networks.tsx
@@ -1,21 +1,28 @@
 "use client";
 import { Link, usePathname } from "../../navigation";
 import { Network } from "../../lib/contracts";
-export default function Networks() {
+
+interface Props {
+  launched?: boolean;
+}
+
+export default function Networks({ launched = false }: Props) {
   const pathname = usePathname();
   const network: Network = pathname.includes("/main") ? "main" : "test";
 
   return (
     <div className="text-sm text-white-400">
       <div className="flex-1 flex justify-center gap-2">
-        <Link
-          href="/main"
-          className={`px-4 py-1 rounded text-sm ${
-            network === "main" ? "bg-orange-600" : "bg-orange-500"
-          } hover:bg-orange-700`}
-        >
-          Mainnet
-        </Link>
+        {launched && (
+          <Link
+            href="/main"
+            className={`px-4 py-1 rounded text-sm ${
+              network === "main" ? "bg-orange-600" : "bg-orange-500"
+            } hover:bg-orange-700`}
+          >
+            Mainnet
+          </Link>
+        )}
         <Link
           href="/test"
           className={`px-4 py-1 rounded text-sm ${

--- a/app/components/NetworksClient.tsx
+++ b/app/components/NetworksClient.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { useEffect, useState } from "react";
+import Networks from "./Networks";
+
+const LAUNCH_DATE = new Date("2025-08-05T20:00:00-03:00").getTime();
+
+export default function NetworksClient() {
+  const [launched, setLaunched] = useState(false);
+
+  useEffect(() => {
+    const check = () => {
+      setLaunched(Date.now() >= LAUNCH_DATE);
+    };
+    check();
+    const id = setInterval(check, 60000);
+    return () => clearInterval(id);
+  }, []);
+
+  return <Networks launched={launched} />;
+}


### PR DESCRIPTION
## Summary
- show mainnet link only after launch date
- add client component to manage launch state
- use new component in layout

## Testing
- `npm run lint` *(fails: interactive ESLint setup)*
- `npm test` *(fails: Hardhat network config errors)*

------
https://chatgpt.com/codex/tasks/task_e_68728a437ef0832f82c2c1ef619da6da