### PR TITLE
Fix referral source in RoomCard

### DIFF
--- a/app/components/RoomCard.tsx
+++ b/app/components/RoomCard.tsx
@@ -45,8 +45,9 @@ export default function RoomCard({ network, id }: Props) {
     const provider = contract.runner as ethers.BrowserProvider;
     const signer = await provider.getSigner();
     const room = await contract.rooms(id);
-    const params = new URLSearchParams(window.location.search);
-    const ref = params.get("ref") || ethers.ZeroAddress;
+    const ref =
+      (typeof window !== "undefined" && localStorage.getItem("referrer")) ||
+      ethers.ZeroAddress;
     const tx = await (contract as any).connect(signer).buyTicket(id, ref, {
       value: room.ticketPrice,
     });


### PR DESCRIPTION
## Summary
- pull referrer ID from `localStorage` instead of querystring when buying a ticket

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687291452ed4832f81d610b6d2664363