### PR TITLE
Fix navbar balance update and disable buy button after draw

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -27,22 +27,32 @@ export default function Navbar() {
     setMounted(true);
   }, []);
 
-  useEffect(() => {
+  async function loadBalance() {
     if (!address) return;
-    async function load() {
-      try {
-        const val = await contract.payments(address);
-        setBalance(ethers.formatEther(val));
-      } catch (err: any) {
-        if (err.code === "BAD_DATA") {
-          setBalance("0");
-        } else {
-          console.error(err);
-        }
+    try {
+      const val = await contract.payments(address);
+      setBalance(ethers.formatEther(val));
+    } catch (err: any) {
+      if (err.code === "BAD_DATA") {
+        setBalance("0");
+      } else {
+        console.error(err);
       }
     }
-    load();
+  }
+
+  useEffect(() => {
+    loadBalance();
+    if (!address) return;
+    const id = setInterval(loadBalance, 10000);
+    return () => clearInterval(id);
   }, [address, contract]);
+
+  useEffect(() => {
+    if (open) {
+      loadBalance();
+    }
+  }, [open]);
 
   async function withdraw() {
     if (!address) return;

--- a/app/components/RoomCard.tsx
+++ b/app/components/RoomCard.tsx
@@ -91,14 +91,18 @@ export default function RoomCard({ network, id }: Props) {
             </span>
           )}
       </div>
-      {winner && <div className="truncate">Winner: {winner}</div>}
+      {winner && winner !== ethers.ZeroAddress && (
+        <div className="truncate">Winner: {winner}</div>
+      )}
       {drawing && <div>Drawing...</div>}
-      <button
-        className="rounded border px-4 py-1 hover:bg-gray-100 dark:hover:bg-gray-800"
-        onClick={buy}
-      >
-        {t("buyTicket", { price: price.toFixed(4), symbol })}
-      </button>
+      {!winner && !drawing && (
+        <button
+          className="rounded border px-4 py-1 hover:bg-gray-100 dark:hover:bg-gray-800"
+          onClick={buy}
+        >
+          {t("buyTicket", { price: price.toFixed(4), symbol })}
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- refresh navbar balance periodically and when the wallet dropdown is opened
- hide winner zero address and disable ticket purchase after the draw

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68729f1242f4832f8f6c676abee6e599